### PR TITLE
Disable LF normalization for all files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Disable LF normalization for all files
+* -text


### PR DESCRIPTION
On a Windows host, there are errors during the set up of a development environment, because GIT default is that text files line endings are normalized. That's what's causing errors in the setup scripts.
Disabled this with .gitattributes, everything is working.
