### PR TITLE
Minor Improvements

### DIFF
--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -45,7 +45,7 @@ def ns_all():
 def home():
     return """
 <html><body>
-    Check out the <strong><pre style="display:inline">docs</pre></strong>
+    Check out the <strong><pre style="display:inline;">docs</pre></strong>
     folder for how to use this API.
 </body></html>
 """

--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -1,4 +1,7 @@
-import os, sys, pkgutil, time
+import os
+import sys
+import pkgutil
+import time
 from inbox.log import get_logger
 
 


### PR DESCRIPTION
## Proposal

Added missing semicolon to HTML tag

Separated imports in `util/misc.py`
## Reasoning

PEP8 recommends separating the imports, it's done everywhere else in this project so might as well correct it here as well.

The missing semicolon is really just for proper CSS formatting.
