### PR TITLE
Fix git converting line endings in binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text eol=lf
+*.png -text
+*.jpg -text


### PR DESCRIPTION
Might be a git issue on my end, but for some reason when I do a new clone I get a state like this:

```
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

    modified:   inbox/monocle/static/favicon.png
    modified:   tests/data/first-attachment.jpg

no changes added to commit (use "git add" and/or "git commit -a")
warning: CRLF will be replaced by LF in inbox/monocle/static/favicon.png.
The file will have its original line endings in your working directory.

$ git diff
warning: CRLF will be replaced by LF in inbox/monocle/static/favicon.png.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in tests/data/first-attachment.jpg.
The file will have its original line endings in your working directory.
diff --git a/inbox/monocle/static/favicon.png b/inbox/monocle/static/favicon.png
index 1b30244..8621ca5 100644
Binary files a/inbox/monocle/static/favicon.png and b/inbox/monocle/static/favicon.png differ
diff --git a/tests/data/first-attachment.jpg b/tests/data/first-attachment.jpg
index 01d9a8c..7a147b6 100644
Binary files a/tests/data/first-attachment.jpg and b/tests/data/first-attachment.jpg differ
```

This .gitattributes rule seems to fix the problem (although if it's an issue with my setup I'd like to know!)
