### PR TITLE
Check for existence of UIDNEXT before casting to long.

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -314,7 +314,8 @@ class CrispinClient(object):
         select_info = self.conn.select_folder(
             folder, readonly=self.readonly)
         select_info['UIDVALIDITY'] = long(select_info['UIDVALIDITY'])
-        select_info['UIDNEXT'] = long(select_info['UIDNEXT'])
+        if 'UIDNEXT' in select_info:
+            select_info['UIDNEXT'] = long(select_info['UIDNEXT'])
         self.selected_folder = (folder, select_info)
         # don't propagate cached information from previous session
         self._folder_names = None


### PR DESCRIPTION
I'm using an IMAP server from Dreamhost.com (not sure what it's running, unfortunately) but the response did not include a UIDNEXT element, causing a crash on sync. This patch fixes it and allows the sync to go through properly.
