### PR TITLE
Docs: remove invalid key from "update thread" example

### DIFF
--- a/inbox/docs/api/05_tags.mdown
+++ b/inbox/docs/api/05_tags.mdown
@@ -75,7 +75,6 @@ PUT https://api.inboxapp.com/n/<namespace_id>/threads/<thread_id>
 ```
 ::json
 {
-    "name": <new tag name>,
     "add_tags": ["housing-search", "craigslist"],
     "remove_tags": ["unread"]
 }


### PR DESCRIPTION
The thread PUT route is only able to have the keys "add_tags" and
"remove_tags" in the request body, otherwise the response is a 400.
