### PR TITLE
setup: changed config file mode bits

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -113,6 +113,7 @@ elif [ $src -nt $dest ]; then
         exit 1
     fi
 fi
+chmod 644 $dest
 
 color '35;1' 'Copying default secrets configuration to /etc/inboxapp'
 src=./etc/secrets-dev.yml
@@ -132,6 +133,7 @@ elif [ $src -nt $dest ]; then
         exit 1
     fi
 fi
+chmod 644 $dest
 
 if $configure_db; then
     # Mysql config


### PR DESCRIPTION
Changed the configuration file mode bits from 600 to 644 for the
/etc/inboxapp/config.json and /etc/inboxapp/secrets.yml configuration
files to avoid issues when starting bin/inbox-start.
