### PR TITLE
Changed 'admin' to 'root' in postinstall-src file.

### DIFF
--- a/docker/postinstall-src
+++ b/docker/postinstall-src
@@ -23,11 +23,11 @@ if [ -e '.git' ]; then
 fi
 
 # Change the ownership & permissions on the source directory
-chown -R admin .
+chown -R root .
 chmod -R u=rwX,g=rX,o=rX .
 
 # Install the package and its dependencies
-sudo -u admin pip install -e .
+sudo -u root pip install -e .
 
 # Clear out potentially stale .pyc files
 # XXX: Is this necessary?


### PR DESCRIPTION
This may have been missed in nylas#109
Was preventing the syncengine_inbox container from being built with error:
"Installing inbox-start script to /usr/local/bin
error: /usr/local/bin/inbox-start: Permission denied"