### PR TITLE
Fix delta API when none of the fetched transaction objects exists.

### DIFF
--- a/inbox/transactions/delta_sync.py
+++ b/inbox/transactions/delta_sync.py
@@ -104,8 +104,8 @@ def format_transactions_after_pointer(namespace, pointer, db_session,
 
     Arguments
     ---------
-    namespace_id: int
-        Id of the namespace for which to get changes.
+    namespace: Namespace
+        Namespace for which to get changes.
     pointer: int
         Process transactions starting after this id.
     db_session: InboxSession
@@ -188,7 +188,7 @@ def format_transactions_after_pointer(namespace, pointer, db_session,
     # Finally, sort deltas by id of the underlying transactions.
     results.sort()
     deltas = [delta for _, delta in results]
-    return (deltas, results[-1][0])
+    return (deltas, transactions[-1].id)
 
 
 def streaming_change_generator(namespace, poll_interval, timeout,


### PR DESCRIPTION
When all deltas are filtered out because `objects.get(trx.record_id)` returns `None` for every object, we would get an error when using the delta API. This patch fixes this behavior and makes sure we get a response with no deltas and a new cursor.