### PR TITLE
Fix read/unread status sync

### DIFF
--- a/inbox/models/thread.py
+++ b/inbox/models/thread.py
@@ -185,10 +185,11 @@ class Thread(MailSyncBase, HasPublicID, HasRevisions):
         elif tag == trash_tag:
             self.tags.discard(inbox_tag)
 
-        unread_tag = self.namespace.tags['unread']
-        if tag == unread_tag:
-            for message in self.messages:
-                message.is_read = False
+        if execute_action:
+            unread_tag = self.namespace.tags['unread']
+            if tag == unread_tag:
+                for message in self.messages:
+                    message.is_read = False
 
     def remove_tag(self, tag, execute_action=False):
         """
@@ -231,9 +232,10 @@ class Thread(MailSyncBase, HasPublicID, HasRevisions):
         elif tag == spam_tag:
             self.tags.add(inbox_tag)
 
-        if tag == unread_tag:
-            for message in self.messages:
-                message.is_read = True
+        if execute_action:
+            if tag == unread_tag:
+                for message in self.messages:
+                    message.is_read = True
 
     @property
     def drafts(self):


### PR DESCRIPTION
Fix read/unread status sync by only marking all messages in a thread as read/unread when an action is performed. This fixes https://github.com/nylas/sync-engine/issues/145