### PR TITLE
Encode folder name when throwing UidInvalid

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -578,8 +578,9 @@ def uidvalidity_cb(account_id, folder_name, select_info):
         if not is_valid:
             raise UidInvalid(
                 'folder: {}, remote uidvalidity: {}, '
-                'cached uidvalidity: {}'.format(
-                    folder_name, selected_uidvalidity, saved_uidvalidity))
+                'cached uidvalidity: {}'.format(folder_name.encode('utf-8'),
+                                                selected_uidvalidity,
+                                                saved_uidvalidity))
     return select_info
 
 


### PR DESCRIPTION
Prevents folders with special characters from being killed with a `UnicodeEncodeError` (sample below):
> {"run_state": "killed", "sync_end_time": {"$date": 1433506798077}, "sync_start_time": {"$date": 1433506758935}, "sync_error": "Traceback (most recent call last):\n\t  File \"/home/ubuntu/inbox/inbox/util/concurrency.py\", line 73, in wrapped\n    return func(*args, **kwargs)\n\t  File \"/home/ubuntu/inbox/inbox/mailsync/backends/imap/generic.py\", line 205, in _run_impl\n    self.state = self.state_handlers[old_state]()\n\t  File \"/home/ubuntu/inbox/inbox/util/concurrency.py\", line 73, in wrapped\n    return func(*args, **kwargs)\n\t  File \"/home/ubuntu/inbox/inbox/mailsync/backends/imap/generic.py\", line 265, in initial_sync\n    crispin_client.select_folder(self.folder_name, uidvalidity_cb)\n\t  File \"/home/ubuntu/inbox/inbox/crispin.py\", line 641, in select_folder\n    self).select_folder(folder, uidvalidity_cb)\n\t  File \"/home/ubuntu/inbox/inbox/crispin.py\", line 347, in select_folder\n    return uidvalidity_cb(self.account_id, folder, select_info)\n\t  File \"/home/ubuntu/inbox/inbox/mailsync/backends/imap/generic.py\", line 582, in uidvalidity_cb\n    folder_name, selected_uidvalidity, saved_uidvalidity))\n\tUnicodeEncodeError: 'ascii' codec can't encode characters in position 8-11: ordinal not in range(128)\n"}