### PR TITLE
Fix database error when Content-ID is too long

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -322,6 +322,8 @@ class Message(MailSyncBase, HasRevisions, HasPublicID):
         block.filename = _trim_filename(filename, mid=mid)
         block.content_type = content_type
         part = Part(block=block, message=self)
+        if content_id:
+            content_id = content_id[:255]
         part.content_id = content_id
         part.content_disposition = content_disposition
         data = mimepart.body or ''

--- a/tests/data/raw_message_with_long_content_id
+++ b/tests/data/raw_message_with_long_content_id
@@ -1,0 +1,19 @@
+From: from@example.com
+To: to@example.com
+Subject: test
+Content-Type: multipart/mixed;
+    boundary="Apple-Mail=_A5779F7D-F2DA-42C3-BE13-48D5C62A02BD"
+
+
+--Apple-Mail=_A5779F7D-F2DA-42C3-BE13-48D5C62A02BD
+Content-Disposition: attachment;
+    filename=attachment.txt
+Content-Type: text/plain;
+    name="attachment.txt"
+Content-Transfer-Encoding: 7bit
+Content-ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+hi
+
+--Apple-Mail=_A5779F7D-F2DA-42C3-BE13-48D5C62A02BD--
+

--- a/tests/general/test_message_parsing.py
+++ b/tests/general/test_message_parsing.py
@@ -33,6 +33,15 @@ def mime_message_with_bad_date(mime_message):
 
 
 @pytest.fixture
+def raw_message_with_long_content_id():
+    # Message that has a long Content-ID
+    raw_msg_path = full_path(
+        '../data/raw_message_with_long_content_id')
+    with open(raw_msg_path) as f:
+        return f.read()
+
+
+@pytest.fixture
 def raw_message_with_ical_invite():
     raw_msg_path = full_path('../data/raw_message_with_ical_invite')
     with open(raw_msg_path) as f:
@@ -294,6 +303,15 @@ def test_store_full_body_on_parse_error(
                                    received_date,
                                    mime_message_with_bad_date.to_string())
     assert m.full_body
+
+
+def test_long_content_id(db, default_account, thread,
+                         raw_message_with_long_content_id):
+    m = create_from_synced(default_account, raw_message_with_long_content_id)
+    m.thread = thread
+    db.session.add(m)
+    # Check that no database error is raised.
+    db.session.commit()
 
 
 def test_parse_body_on_bad_attachment(


### PR DESCRIPTION
Fixes the following error:
`DataError: (DataError) (1406, u"Data too long for column 'content_id' at row 1") 'INSERT INTO part (created_at, updated_at, deleted_at, block_id, message_id, walk_index, content_disposition, content_id) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)' (datetime.datetime(2015, 6, 14, 4, 0, 0, 734872), datetime.datetime(2015, 6, 14, 4, 0, 0, 734889), None, 52, 17, None, 'attachment', u'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')`