### PR TITLE
Fix ValueError in get_heartbeat_status

### DIFF
--- a/inbox/heartbeat/status.py
+++ b/inbox/heartbeat/status.py
@@ -19,8 +19,12 @@ class DeviceHeartbeatStatus(object):
 
     def __init__(self, device_id, device_status, threshold=ALIVE_THRESHOLD):
         self.id = device_id
-        self.heartbeat_at = datetime.strptime(device_status['heartbeat_at'],
-                                              '%Y-%m-%d %H:%M:%S.%f')
+        try:
+            self.heartbeat_at = datetime.strptime(device_status['heartbeat_at'],
+                                                  '%Y-%m-%d %H:%M:%S.%f')
+        except ValueError:
+            self.heartbeat_at = datetime.strptime(device_status['heartbeat_at'],
+                                                  '%Y-%m-%d %H:%M:%S')
         self.state = device_status.get('state', None)
         time_since_heartbeat = (datetime.utcnow() - self.heartbeat_at)
         self.alive = time_since_heartbeat < threshold


### PR DESCRIPTION
If the millisecond portion of the heartbeat is 0 then `get_heartbeat_status` fails with a `ValueError` because the format doesn't match. This PR fixes the issue.

Here is a sample traceback:
```
    heartbeat = get_heartbeat_status()
  File "/home/ubuntu/inbox/inbox/heartbeat/status.py", line 154, in get_heartbeat_status
    ALIVE_THRESHOLD)
  File "/home/ubuntu/inbox/inbox/heartbeat/status.py", line 52, in __init__
    device = DeviceHeartbeatStatus(device_id, device_status, threshold)
  File "/home/ubuntu/inbox/inbox/heartbeat/status.py", line 23, in __init__
    '%Y-%m-%d %H:%M:%S.%f')
  File "/usr/lib/python2.7/_strptime.py", line 325, in _strptime
    (data_string, format))
ValueError: time data '2015-06-22 08:22:23' does not match format '%Y-%m-%d %H:%M:%S.%f'
```