### PR TITLE
Catch OverflowError in handle_charref

### DIFF
--- a/inbox/util/html.py
+++ b/inbox/util/html.py
@@ -41,7 +41,7 @@ class HTMLTagStripper(HTMLParser):
             else:
                 val = int(d)
             self.fed.append(unichr(val))
-        except ValueError:
+        except (ValueError, OverflowError):
             return
 
     def handle_entityref(self, d):


### PR DESCRIPTION
```
	  File "/home/ubuntu/inbox/inbox/models/message.py", line 360, in calculate_body
    self.snippet = self.calculate_html_snippet(html_body)
	  File "/home/ubuntu/inbox/inbox/models/message.py", line 376, in calculate_html_snippet
    text = strip_tags(text)
	  File "/home/ubuntu/inbox/inbox/util/html.py", line 61, in strip_tags
    s.feed(html)
	  File "/usr/lib/python2.7/HTMLParser.py", line 117, in feed
    self.goahead(0)
	  File "/usr/lib/python2.7/HTMLParser.py", line 191, in goahead
    self.handle_charref(name)
	  File "/home/ubuntu/inbox/inbox/util/html.py", line 43, in handle_charref
    self.fed.append(unichr(val))
	OverflowError: signed integer is greater than maximum
```