### PR TITLE
fetch_corresponding_thread SQL performance optimization

### DIFF
--- a/inbox/util/threading.py
+++ b/inbox/util/threading.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from inbox.models.thread import Thread
 from sqlalchemy import desc
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, load_only
 from inbox.util.misc import cleanup_subject
 
 
@@ -19,8 +19,10 @@ def fetch_corresponding_thread(db_session, namespace_id, message):
         filter(Thread.namespace_id == namespace_id,
                Thread._cleaned_subject == clean_subject). \
         order_by(desc(Thread.id)). \
-        options(joinedload(Thread.messages).load_only(
-            'from_addr', 'to_addr', 'bcc_addr', 'cc_addr'))
+        options(load_only('id', 'discriminator'),
+                joinedload(Thread.messages).load_only(
+                    'from_addr', 'to_addr', 'bcc_addr', 'cc_addr'). \
+                    noload('namespace'))
 
     for thread in threads:
         for match in thread.messages:


### PR DESCRIPTION
1) Don't load unnecessary fields on the Thread
2) Don't join account and namespace tables unnecessarily

This combined with an index (#169) will speed this function up. However, there is still potential for more optimization. What do you think about adding a LIMIT 1000 clause to the query?