### PR TITLE
Limit number of messages we fetch at a time when doing gc

### DIFF
--- a/inbox/mailsync/gc.py
+++ b/inbox/mailsync/gc.py
@@ -9,6 +9,7 @@ from inbox.util.debug import bind_context
 log = get_logger()
 
 DEFAULT_MESSAGE_TTL = 120
+MAX_FETCH = 1000
 
 
 class DeleteHandler(gevent.Greenlet):
@@ -59,7 +60,8 @@ class DeleteHandler(gevent.Greenlet):
         with session_scope() as db_session:
             dangling_messages = db_session.query(Message).filter(
                 Message.namespace_id == self.namespace_id,
-                Message.deleted_at <= current_time - self.message_ttl)
+                Message.deleted_at <= current_time - self.message_ttl
+            ).limit(MAX_FETCH)
             for message in dangling_messages:
                 # If the message isn't *actually* dangling (i.e., it has
                 # imapuids associated with it), undelete it.


### PR DESCRIPTION
For large accounts, this may cause a lot of data being transmitted, so only fetch a limited number of messages per gc iteration.

Should we also constrain fields instead of fetching the entire messages?