### PR TITLE
Update dependencies for IMAPClient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ msgpack-python==0.4.2
 guppy==0.1.10
 redis==2.10.3
 hiredis==0.1.5
-mock==1.0.1
+mock==1.3.0
 mockredispy==2.9.0.10
 vobject==0.8.1c
 lxml==3.4.2

--- a/setup.sh
+++ b/setup.sh
@@ -73,6 +73,7 @@ echo "mysql-server mysql-server/root_password_again password root";
 
 color '35;1' 'Installing dependencies from apt-get...'
 apt-get -y install git \
+                   mercurial \
                    wget \
                    supervisor \
                    mysql-server \


### PR DESCRIPTION
Commit 01035a24cd3d783a2326ebf77be0465c76cfbd71, that uses an intermediate IMAPClient revision introduced a couple of dependencies- Mercurial to fetch it from bitbucket, and a newer version of Mock.





