### PR TITLE
install mercurial in setup for bitbucket hg command used in imapclient

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -96,6 +96,7 @@ apt-get -y install git \
                    curl \
                    tnef \
                    stow \
+		   mercurial
 
 # Switch to a temporary directory to install dependencies, since the source
 # directory might be mounted from a VM host with weird permissions.


### PR DESCRIPTION
without installing mercurial,  installing imapclient will fail.