### PR TITLE
Include mercurial in the VM's dependency list

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -73,6 +73,7 @@ echo "mysql-server mysql-server/root_password_again password root";
 
 color '35;1' 'Installing dependencies from apt-get...'
 apt-get -y install git \
+                   mercurial \
                    wget \
                    supervisor \
                    mysql-server \


### PR DESCRIPTION
Mercurial is necessary because requirements.txt specifies an hg url (as of nylas/sync-engine@01035a24cd3d783a2326ebf77be0465c76cfbd71)