### PR TITLE
Fix dependency issues in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM debian:wheezy
 MAINTAINER inboxapp
 RUN apt-get -q update && \
     DEBIAN_FRONTEND=noninteractive apt-get -qy install \
+        mercurial \
         anacron \
         build-essential \
         cron \
@@ -35,7 +36,7 @@ RUN apt-get -q update && \
         tnef \
         wget \
     && \
-    pip install 'setuptools>=5.3' subprocess32 tox
+    pip install 'pip>=1.5.6' 'setuptools>=5.3' subprocess32 tox
 
 RUN useradd -ms /bin/sh admin && \
     install -d -m0775 -o root -g admin /srv/inbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ FROM debian:wheezy
 MAINTAINER inboxapp
 RUN apt-get -q update && \
     DEBIAN_FRONTEND=noninteractive apt-get -qy install \
-        mercurial \
         anacron \
         build-essential \
         cron \
@@ -21,6 +20,7 @@ RUN apt-get -q update && \
         libxml2-dev \
         libxslt-dev \
         libzmq-dev \
+        mercurial \
         mysql-client \
         net-tools \
         procps \


### PR DESCRIPTION
This change fixes some dependency issues with the dockerfile and brings it up to par with the dependencies as listed in [the setup.sh file.](https://github.com/nylas/sync-engine/blob/master/setup.sh)

Here is a failed run off master: http://pastebin.com/RD8CpyfL
Here is a successful run off my branch: http://pastebin.com/pYLxckvP
