### PR TITLE
Allow use of PATCH to follow REST semantics

### DIFF
--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -274,7 +274,7 @@ def thread_api(public_id):
 #
 # Update thread
 #
-@app.route('/threads/<public_id>', methods=['PUT'])
+@app.route('/threads/<public_id>', methods=['PUT', 'PATCH'])
 def thread_api_update(public_id):
     try:
         valid_public_id(public_id)

--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -89,7 +89,7 @@ def finish(response):
         response.headers['Access-Control-Allow-Origin'] = origin
         response.headers['Access-Control-Allow-Headers'] = 'Authorization'
         response.headers['Access-Control-Allow-Methods'] = \
-            'GET,PUT,POST,DELETE,OPTIONS'
+            'GET,PUT,POST,DELETE,OPTIONS,PATCH'
         response.headers['Access-Control-Allow-Credentials'] = 'true'
     return response
 


### PR DESCRIPTION
#### :tophat: What? Why?

Current implementation forces the use of `PUT` for updating threads. This is conflicting with some REST clients (like Backbone for instance). `PUT` is for updating the whole resource so the correct verb to be used to send something like `undread: false` is `PATCH`.

#### :ghost: GIF
![](https://media.giphy.com/media/b9QBHfcNpvqDK/giphy.gif)