### PR TITLE
Allow Content-Type headers

### DIFF
--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -87,7 +87,7 @@ def finish(response):
     origin = request.headers.get('origin')
     if origin:  # means it's just a regular request
         response.headers['Access-Control-Allow-Origin'] = origin
-        response.headers['Access-Control-Allow-Headers'] = 'Authorization'
+        response.headers['Access-Control-Allow-Headers'] = 'Authorization,Content-Type'
         response.headers['Access-Control-Allow-Methods'] = \
             'GET,PUT,POST,DELETE,OPTIONS'
         response.headers['Access-Control-Allow-Credentials'] = 'true'


### PR DESCRIPTION
#### :tophat: What? Why?

This is preventing some clients to work since they send the header by default.

#### :ghost: GIF
![](https://media.giphy.com/media/ubx2SB9C4yNoY/giphy.gif)