### PR TITLE
Update vobject in requirements.txt to match pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ hiredis==0.1.5
 mock==1.3.0
 mockredispy==2.9.0.10
 lunatic-python-bugfix==1.1.1  # For Redis mocking in tests
-vobject==0.8.1c
+vobject==0.8.1c-dist
 lxml==3.4.2
 arrow==0.5.4
 hypothesis==1.10.3


### PR DESCRIPTION
From `pip install -r requirements.txt`:

`Could not find a version that satisfies the requirement vobject==0.8.1c (from -r requirements.txt (line 50)) (from versions: 0.2.3, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.4.6, 0.4.7, 0.4.8, 0.4.9, 0.5.0, 0.6.6, 0.8.1c-dist)`