### PR TITLE
send email from the alias instead of the main account

### DIFF
--- a/inbox/sendmail/smtp/postel.py
+++ b/inbox/sendmail/smtp/postel.py
@@ -253,14 +253,17 @@ class SMTPConnection(object):
 
         self.log.info('SMTP Auth(Password) success')
 
-    def sendmail(self, recipients, msg):
+    def sendmail(self, recipients, msg, from_email=None):
+        if from_email is None:
+            from_email = self.email_address
+
         try:
             return self.connection.sendmail(
-                self.email_address, recipients, msg)
+                from_email, recipients, msg)
         except UnicodeEncodeError:
             self.log.error('Unicode error when trying to decode email',
                            logstash_tag='sendmail_encode_error',
-                           email=self.email_address, recipients=recipients)
+                           email=from_email, recipients=recipients)
             raise SendMailException(
                 'Invalid character in recipient address', 402)
 
@@ -300,7 +303,7 @@ class SMTPClient(object):
                 # non-generic accounts have no smtp password
                 self.auth_token = account.password
 
-    def _send(self, recipients, msg):
+    def _send(self, recipients, msg, from_email=None):
         """Send the email message. Retries up to SMTP_MAX_RETRIES times if the
         message couldn't be submitted to any recipient.
 
@@ -319,7 +322,7 @@ class SMTPClient(object):
         for _ in range(SMTP_MAX_RETRIES + 1):
             try:
                 with self._get_connection() as smtpconn:
-                    failures = smtpconn.sendmail(recipients, msg)
+                    failures = smtpconn.sendmail(recipients, msg, from_email=from_email)
                     if not failures:
                         # Sending successful!
                         return
@@ -407,8 +410,9 @@ class SMTPClient(object):
 
         # from_addr is only ever a list with one element
         from_addr = draft.from_addr[0]
+        from_email = from_addr[1]
         msg = create_email(from_name=from_addr[0],
-                           from_email=from_addr[1],
+                           from_email=from_email,
                            reply_to=draft.reply_to,
                            inbox_uid=draft.inbox_uid,
                            to_addr=draft.to_addr,
@@ -422,7 +426,7 @@ class SMTPClient(object):
 
         recipient_emails = [email for name, email in itertools.chain(
             draft.to_addr, draft.cc_addr, draft.bcc_addr)]
-        self._send(recipient_emails, msg)
+        self._send(recipient_emails, msg, from_email=from_email)
 
         # Sent to all successfully
         self.log.info('Sending successful', sender=from_addr[1],

--- a/tests/api/test_sending.py
+++ b/tests/api/test_sending.py
@@ -67,7 +67,7 @@ def patch_smtp(patch_token_manager, monkeypatch):
         def __exit__(self, exc_type, value, traceback):
             pass
 
-        def sendmail(self, recipients, msg):
+        def sendmail(self, recipients, msg, from_email=None):
             submitted_messages.append((recipients, msg))
 
     monkeypatch.setattr('inbox.sendmail.smtp.postel.SMTPConnection',
@@ -87,7 +87,7 @@ def erring_smtp_connection(exc_type, *args):
         def __exit__(self, exc_type, value, traceback):
             pass
 
-        def sendmail(self, recipients, msg):
+        def sendmail(self, recipients, msg, from_email=None):
             raise exc_type(*args)
 
     return ErringSMTPConnection


### PR DESCRIPTION
I noticed this when setting up an account in N1:  If you send an email from an alias, it'll set the FROM header to the alias, but it'll still use the account's main email in the MAIL FROM smtp command.  This causes the return path to contain the main account's email instead of the alias'.  This isn't desirable in a lot of cases, since it'll leak the main account's email for any emails sent from the alias.

In my case, I have a fastmail address, plus several of my domains that fastmail handles.  If I send an email from my domain, I don't want my main fastmail address to appear in the headers, and I want the DKIM/SPF checks to be against my domain and not fastmail's.

Here's an example where I changed some emails and deleted extra headers, but it's basically real.  fakemainaccount@eml.cc is a (fake) fastmail address, and appears when I send email from mydomain.example.com:

```
Return-Path: <fakemainaccount@eml.cc>
Received-SPF: pass (google.com: domain of fakemainaccount@eml.cc designates 66.111.4.224 as permitted sender) client-ip=66.111.4.224;
Authentication-Results: mx.google.com;
       spf=pass (google.com: domain of fakemainaccount@eml.cc designates 66.111.4.224 as permitted sender) smtp.mailfrom=fakemainaccount@eml.cc;
       dkim=pass header.i=@mydomain.example.com;
       dkim=pass header.i=@messagingengine.com
DKIM-Signature: v=1; a=rsa-sha1; c=relaxed/relaxed; d=mydomain.example.com; h=
	content-type:date:from:message-id:mime-version:subject:to
	:x-sasl-enc:x-sasl-enc; s=mesmtp; bh=38OGDUVH4qtC8WGjYv1ZawQbqLg
	=; b=RkFOq0jSmJXcag/03IMd2Zrh+72tiPZ/i4WYXGGpZutshLM+CBZ5jm1yRb4
	eq0PpHGWIOnwJMewftQgnhftTY3v6PVjl25V3mufT3m8U5jSzs5vzn3ZSXrmEPg4
	2Zn7LcO9LiqeBqKg+F65PET58GrtljGoR9k/11Ki7KRpiwnA=
To: email@gmail.example.com
From: Brandon Dimcheff <brandon@mydomain.example.com>
Subject: test a thing
```

The requests from N1 appear to be correct, ie. they send the correct "from" address to the sync engine, so I did some digging in here and found the call into smtplib that is causing MAIL FROM to be the account's email.

I'm not sure that my solution is actually the right way to solve this problem, since this PR changes the call into smtplib so it uses the supplied from address instead of the email from the account itself.  I tried it via curl and a local copy of the sync engine and it did indeed prevent my main account email from being exposed in the headers.  If this behavior change is something you guys agree with, I'm happy to work on it more.

Since this changes the behavior of the existing API, a different backwards-compatible solution is something like:  add an optional `mail_from` key to the send API so that defaults to "main" but you can specify "alias" if you want it to use the alias's email.  That'd obviously require some changes to N1 as well, but it wouldn't change existing API behavior.

Thoughts?

Thanks!
\- brandon