### PR TITLE
Fixes setup.sh execution on Debian 8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ boto==2.10.0
 ipython==1.0.0
 Flask==0.10.1
 freezegun==0.3.6
-gevent==1.0.1
+gevent==1.0.2
 gevent-socketio==0.3.5-rc2
 gunicorn==19.0.0
 mysqlclient==1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,4 @@ gevent_openssl==1.2
 backports.ssl==0.0.9
 imapclient==1.0.1
 tldextract==1.7.5
+cffi>=1.6

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(),
 
     install_requires=[
-        "gevent>=1.0.1",
+        "gevent>=1.0.2",
         "nylas-production-python>=0.2.0",
         "click>=2.4",
         "cpu_affinity>=0.1.0",

--- a/setup.sh
+++ b/setup.sh
@@ -90,6 +90,7 @@ apt-get -y install git \
                    libxslt-dev \
                    lib32z1-dev \
                    libffi-dev \
+                   libssl-dev \
                    pkg-config \
                    python-lxml \
                    tmux \

--- a/setup.sh
+++ b/setup.sh
@@ -100,6 +100,8 @@ apt-get -y install git \
                    lua5.2 \
                    liblua5.2-dev \
 
+apt-get --purge remove -y python-cffi
+
 # Switch to a temporary directory to install dependencies, since the source
 # directory might be mounted from a VM host with weird permissions.
 src_dir=$(pwd)

--- a/setup.sh
+++ b/setup.sh
@@ -100,9 +100,6 @@ apt-get -y install git \
                    lua5.2 \
                    liblua5.2-dev \
 
-# Upgrade pip
-pip install -U pip
-
 # Switch to a temporary directory to install dependencies, since the source
 # directory might be mounted from a VM host with weird permissions.
 src_dir=$(pwd)

--- a/setup.sh
+++ b/setup.sh
@@ -100,7 +100,8 @@ apt-get -y install git \
                    lua5.2 \
                    liblua5.2-dev \
 
-apt-get --purge remove -y python-cffi
+# Upgrade pip
+pip install -U pip
 
 # Switch to a temporary directory to install dependencies, since the source
 # directory might be mounted from a VM host with weird permissions.


### PR DESCRIPTION
Currently setup.sh keeps failing for me on a Debian 8 VM. Turns out the error is similar to here https://github.com/pyca/cryptography/issues/2280, which is due to apt installed of cffi version being less than 1.1. 

```
Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/cryptography/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-X8h31p-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/cryptography
Storing debug log for failure in /home/nikolai/.pip/pip.log
```

This PR also fixes #261 #267 #268 
-  setup.sh script now installs libssl-dev #261
- Update the minimum gevent version to 1.0.2 #267 
- added `cffi` to requirements.txt file which fixes the error in https://github.com/pyca/cryptography/issues/2280  and #268 
