### PR TITLE
Replace <p> tags by space in strip_tags

### DIFF
--- a/inbox/util/html.py
+++ b/inbox/util/html.py
@@ -17,8 +17,8 @@ class HTMLTagStripper(HTMLParser):
         self.strip_tag_contents_mode = False
 
     def handle_starttag(self, tag, attrs):
-        # Replace <br>, <div> tags by spaces
-        if tag.lower() in ('br', 'div'):
+        # Replace <br>, <div>, <p> tags by spaces
+        if tag.lower() in ('br', 'div', 'p'):
             self.fed.append(' ')
         # Strip the contents of a tag when it's
         # in strippedTags. We can do this because


### PR DESCRIPTION
Stripping tags from `<p>two</p><p>line</p>` should result in `two line`, not `twoline`.