### PR TITLE
Draft Syncback Fixes

### DIFF
--- a/inbox/actions/backends/generic.py
+++ b/inbox/actions/backends/generic.py
@@ -183,7 +183,7 @@ def remote_save_draft(account_id, message_id):
         crispin_client.save_draft(mimemsg)
 
 
-def remote_update_draft(account_id, message_id):
+def remote_update_draft(account_id, message_id, old_message_id_header):
     with session_scope(account_id) as db_session:
         account = db_session.query(Account).get(account_id)
         message = db_session.query(Message).get(message_id)
@@ -192,30 +192,33 @@ def remote_update_draft(account_id, message_id):
         version = message.version
         mimemsg = _create_email(account, message)
 
+    # Steps to updating draft:
+    # 1. Create the new message, unless it's somehow already there
+    # 2. Delete the old message the API user is updating
+
     with writable_connection_pool(account_id).get() as crispin_client:
         if 'drafts' not in crispin_client.folder_names():
-            log.info('Account has no detected drafts folder; not saving draft',
+            log.info('Account has no drafts folder. Will not save draft.',
                      account_id=account_id)
             return
         folder_name = crispin_client.folder_names()['drafts'][0]
         crispin_client.select_folder(folder_name, uidvalidity_cb)
-        existing_copy = crispin_client.find_by_header(
+        existing_new_draft = crispin_client.find_by_header(
             'Message-Id', message_id_header)
-        if not existing_copy:
+        if not existing_new_draft:
             crispin_client.save_draft(mimemsg)
         else:
-            log.info('Not saving draft; copy already exists on remote',
+            log.info('Draft has been saved, will not create a duplicate.',
                      message_id_header=message_id_header)
 
         # Check for an older version and delete it. (We can stop once we find
         # one, to reduce the latency of this operation.)
-        for old_version in reversed(range(0, version)):
-            message_id_header = '<{}-{}@mailer.nylas.com>'.format(
-                message_public_id, old_version)
-            old_version_deleted = crispin_client.delete_draft(
-                message_id_header)
-            if old_version_deleted:
-                break
+        old_version_deleted = crispin_client.delete_draft(
+            old_message_id_header)
+        if old_version_deleted:
+            log.info('Cleaned up old draft',
+                     old_message_id_header=old_message_id_header,
+                     message_id_header=message_id_header)
 
 
 def remote_delete_draft(account_id, inbox_uid, message_id_header):

--- a/inbox/actions/base.py
+++ b/inbox/actions/base.py
@@ -118,6 +118,8 @@ def update_draft(account_id, message_id, args):
     with session_scope(account_id) as db_session:
         message = db_session.query(Message).get(message_id)
         version = args.get('version')
+        old_message_id_header = args.get('old_message_id_header')
+
         if message is None:
             log.info('tried to save nonexistent message as draft',
                      message_id=message_id, account_id=account_id)
@@ -131,7 +133,7 @@ def update_draft(account_id, message_id, args):
             log.warning('tried to save outdated version of draft')
             return
 
-    remote_update_draft(account_id, message_id)
+    remote_update_draft(account_id, message_id, old_message_id_header)
 
 
 def delete_draft(account_id, draft_id, args):


### PR DESCRIPTION
There are two fixes in here, and some cleaned up comments:

- Set `is_created` when updating drafts, so that reconciliation always works. Previously, updating a draft authored on Gmail would create two drafts, because our reconcilation code only checks for MessageID matches with locally created drafts.

- Allow `remote_update_draft` to delete a non-Nylas `MessageID`. Previously, it tried decrementing the version number and deleting that MessageID if it existed. If you're updating a Gmail draft, the message ID is not a Nylas versioned ID, just a random string. By being explicit about the message ID we intend to be replacing, we can probably ensure that `PUT /draft/id` reliably deletes+creates the message it is updating.

Tests? How do they work?