### PR TITLE
Use more secure TLS validation

### DIFF
--- a/inbox/config.py
+++ b/inbox/config.py
@@ -2,6 +2,14 @@ import errno
 import os
 import yaml
 
+# TODO[mike]: This should be removed once we've updated python to 2.7.9 which has better ssl support
+import urllib3.contrib.pyopenssl
+urllib3.contrib.pyopenssl.inject_into_urllib3()
+
+# TODO[mike]: This shold be removed once we've updated our base OS. openssl 1.0.1 doesn't support cross-signed certs
+# https://github.com/certifi/python-certifi/issues/26#issuecomment-138322515
+os.environ["REQUESTS_CA_BUNDLE"] = "/usr/local/lib/python2.7/dist-packages/certifi/weak.pem"
+
 __all__ = ['config']
 
 

--- a/inbox/contacts/google.py
+++ b/inbox/contacts/google.py
@@ -85,8 +85,8 @@ class GoogleContactsProvider(object):
                     account, force_refresh=True)
                 return self._google_client(retry_conn_errors=False)
 
-            except ConnectionError:
-                self.log.error('Connection error')
+            except ConnectionError as e:
+                self.log.error('Connection error', error=e)
                 raise
 
     def _parse_contact_result(self, google_contact):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,12 @@ boto==2.10.0
 ipython==1.0.0
 Flask==0.10.1
 freezegun==0.3.7
-gevent==1.0.1
+gevent==1.1.2
 gevent-socketio==0.3.5-rc2
 gunicorn==19.4.5
 mysqlclient==1.3.7
-requests==2.4.3
+requests[security]==2.10.0
+urllib3[secure]==1.16
 chardet==2.1.1
 setproctitle==1.1.8
 gdata==2.0.18


### PR DESCRIPTION
Upgrades gevent, requests, and urllib3 to get support for the latest TLS protocol versions. In some cases, users were unable to verify their webhooks hosted on services like AWS because AWS rejects insecure SSLv3 and SSLv2 (for good reason!). 

Note: This commit also contains a temporary hack due to our inability to upgrade from openssl 1.0.1 on our base OS. Certificate verification will fail when making requests to servers with cross-signed certificates, so we must rely on certifi which currently retains older, insecure 1024-bit keys. 