### PR TITLE
Don't sleep for 30s during folder sync tests

### DIFF
--- a/tests/general/test_concurrency.py
+++ b/tests/general/test_concurrency.py
@@ -30,6 +30,7 @@ class FailingFunction(object):
             raise self.exc_type
         return
 
+
 @pytest.mark.usefixtures('mock_gevent_sleep')
 def test_retry_with_logging():
     logger = MockLogger()

--- a/tests/general/test_provider_resolution.py
+++ b/tests/general/test_provider_resolution.py
@@ -8,12 +8,14 @@ from inbox.auth.generic import GenericAuthHandler
 from inbox.auth.gmail import GmailAuthHandler
 from inbox.basicauth import NotSupportedError
 
+
 class MockAnswer(object):
     def __init__(self, exchange):
         self.exchange = exchange
 
     def __str__(self):
         return self.exchange
+
 
 class MockDNSResolver(object):
     def __init__(self, registry_filename):
@@ -35,7 +37,6 @@ class MockDNSResolver(object):
 
 
 def test_provider_resolution():
-    pfa = provider_from_address
     dns_resolver = MockDNSResolver('dns.json')
     test_cases = [
         ('foo@example.com', 'unknown'),

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -103,6 +103,12 @@ class MockIMAPClient(object):
         self.selected_folder = None
         self.uidvalidity = 1
 
+    def idle_check(self, timeout=None):
+        return []
+
+    def idle_done(self):
+        return ('Idle terminated', [])
+
     def add_folder_data(self, folder_name, uids):
         """Adds fake UID data for the given folder."""
         self._data[folder_name] = uids
@@ -189,7 +195,7 @@ class MockIMAPClient(object):
             'UIDVALIDITY': self.uidvalidity
         }
         if data and 'HIGHESTMODSEQ' in data:
-            resp['HIGHESTMODSEQ'] = max(v['MODSEQ'][0] for v in
+            resp['HIGHESTMODSEQ'] = max(v['MODSEQ'] for v in
                                         folder_data.values())
         return resp
 


### PR DESCRIPTION
Fixes #331 

Summary: 
This was slowing our folder sync tests way down. We now properly mock gevent
such that we don't actually sleep.

Test Plan: unit tests

Reviewers:
Please add the reviewer as an assignee to this PR on the right