### PR TITLE
Reduce amount of test data generated by hypothesis

### DIFF
--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -60,7 +60,7 @@ address = s.builds(
 addresslist = s.lists(
     s.tuples(basic_text, address),
     min_size=1,
-    max_size=10
+    max_size=5
 )
 
 
@@ -90,7 +90,8 @@ uid_data = s.builds(
 uids = s.dictionaries(
     s.integers(min_value=22),
     uid_data,
-    min_size=24)
+    min_size=5,
+    max_size=10)
 
 
 class MockIMAPClient(object):


### PR DESCRIPTION
Fixes #333

Summary: We use hypothesis to autogenerate random test data for some of our IMAP sync
tests. The generation of this data is actually quite expensive due to the
amount of data we were generating. It also causes our tests to run slower since
we have so much data to process. This diff cuts down the amount of data we're
generating by around an order of magnitude.

Test Plan: Run unit tests, verify they're faster

Reviewers: spang, bengotow
Please add the reviewer as an assignee to this PR on the right
