### PR TITLE
Sleep less, test more

### DIFF
--- a/tests/general/test_namespace.py
+++ b/tests/general/test_namespace.py
@@ -188,8 +188,7 @@ def test_deletion_no_throttle(db, patch_requests_no_throttle):
 
     to_delete = get_accounts_to_delete(0)
     greenlet = gevent.spawn(delete_marked_accounts, 0, to_delete, throttle=True)
-    gevent.sleep(5)
-    gevent.kill(greenlet)
+    greenlet.join()
 
     alive_accounts = db.session.query(Account.id).all()
 
@@ -214,8 +213,7 @@ def test_deletion_metric_throttle(db, patch_requests_throttle):
 
     to_delete = get_accounts_to_delete(0)
     greenlet = gevent.spawn(delete_marked_accounts, 0, to_delete, throttle=True)
-    gevent.sleep(5)
-    gevent.kill(greenlet)
+    greenlet.join()
 
     alive_accounts = [acc.id for acc in db.session.query(Account).all()]
 
@@ -241,8 +239,7 @@ def test_deletion_time_throttle(db, patch_requests_no_throttle):
 
     to_delete = get_accounts_to_delete(0)
     greenlet = gevent.spawn(delete_marked_accounts, 0, to_delete, throttle=True)
-    gevent.sleep(2)
-    gevent.kill(greenlet)
+    greenlet.join()
 
     alive_accounts = [acc.id for acc in db.session.query(Account).all()]
 

--- a/tests/imap/test_delete_handling.py
+++ b/tests/imap/test_delete_handling.py
@@ -242,8 +242,7 @@ def test_renamed_label_refresh(db, default_account, thread, message,
     semaphore.acquire()
     rename_handler.start()
 
-    # Wait 10 secs and check that the data hasn't changed.
-    gevent.sleep(10)
+    gevent.sleep(0) # yield to the handler
 
     labels = list(imapuid.labels)
     assert len(labels) == 1

--- a/tests/scheduling/test_syncback_logic.py
+++ b/tests/scheduling/test_syncback_logic.py
@@ -99,7 +99,7 @@ def test_actions_are_claimed(purge_accounts_and_actions, patched_task):
     service._process_log()
 
     while not service.task_queue.empty():
-        gevent.sleep(0.1)
+        gevent.sleep(0)
 
     with session_scope_by_shard_id(0) as db_session:
         q = db_session.query(ActionLog)

--- a/tests/security/test_smtp_ssl.py
+++ b/tests/security/test_smtp_ssl.py
@@ -82,7 +82,7 @@ def test_smtp_ssl_verification_bad_cert(db, bad_cert_smtp_server,
                                         api_client, patched_smtp):
 
     api_client = new_api_client(db, local_smtp_account.namespace)
-    gevent.sleep(0.2)  # let SMTP daemon start up
+    gevent.sleep(0)  # let SMTP daemon start up
     r = api_client.post_data('/send', example_draft)
     assert r.status_code == 200
 


### PR DESCRIPTION
Fixes #337 

Summary: There are a number of tests that are using calls to sleep to achieve an effect
that they could get more precisely from something else (e.g. join). Let's
change these call sites so that we don't have to waste a bunch of time sleeping
during our tests.

Test Plan: unit tests

Reviewers: spang bengotow
Please add the reviewer as an assignee to this PR on the right
