### PR TITLE
Fix SQLAlchemy package requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ httplib2==0.8
 pytest==2.5.2
 pytest-xdist==1.11
 wsgiref==0.1.2
-git+https://github.com/mhahnenberg/sqlalchemy.git@d91084a3dcb0b770b6b0bb884d4a3f2e55770f60#egg=SQLAlchemy
+git+https://github.com/mhahnenberg/sqlalchemy.git@backport-fix#egg=SQLAlchemy
 pymongo==2.5.2  # For json_util in bson
 dnspython==1.11.1
 boto==2.10.0


### PR DESCRIPTION
Summary: We based our fix on the 1.1.0beta3 release of SQLAlchemy which caused some
tests to start failing mysteriously. Upon forcing a downgrade of the package to
1.0.14 the tests started passing again. We've updated our fork by backporting
the baked query fix to the 1.0.14 release which we now reference in
requirements.txt.

Test Plan: Run the failing tests locally, they pass now. Run it on Jenkins, Travis CI, etc to verify builds are no longer broken.

Reviewers: spang
Please add the reviewer as an assignee to this PR on the right
