### PR TITLE
Mock out DNS resolver for provider resolution test

### DIFF
--- a/inbox/util/url.py
+++ b/inbox/util/url.py
@@ -39,7 +39,7 @@ def _fallback_get_mx_domains(domain):
         return []
 
 
-def get_mx_domains(domain):
+def get_mx_domains(domain, dns_resolver=dns_resolver):
     """ Retrieve and return the MX records for a domain. """
     mx_records = []
     try:
@@ -84,12 +84,12 @@ def mx_match(mx_domains, match_domains):
     return False
 
 
-def provider_from_address(email_address):
+def provider_from_address(email_address, dns_resolver=dns_resolver):
     if not EMAIL_REGEX.match(email_address):
         raise InvalidEmailAddressError('Invalid email address')
 
     domain = email_address.split('@')[1].lower()
-    mx_domains = get_mx_domains(domain)
+    mx_domains = get_mx_domains(domain, dns_resolver)
     ns_records = []
     try:
         ns_records = dns_resolver.query(domain, 'NS')

--- a/tests/data/dns.json
+++ b/tests/data/dns.json
@@ -1,0 +1,403 @@
+[{
+    "domain": "example.com",
+    "mx_domains": [],
+    "ns_records": [
+        "b.iana-servers.net.",
+        "a.iana-servers.net."
+    ]
+},
+{
+    "domain": "noresolve.com",
+    "mx_domains": [],
+    "ns_records": [
+        "buy.internettraffic.com.",
+        "sell.internettraffic.com."
+    ]
+},
+{
+    "domain": "gmail.com",
+    "mx_domains": [
+        "alt1.gmail-smtp-in.l.google.com.",
+        "alt2.gmail-smtp-in.l.google.com.",
+        "gmail-smtp-in.l.google.com.",
+        "alt4.gmail-smtp-in.l.google.com.",
+        "alt3.gmail-smtp-in.l.google.com."
+    ],
+    "ns_records": [
+        "ns3.google.com.",
+        "ns4.google.com.",
+        "ns2.google.com.",
+        "ns1.google.com."
+    ]
+},
+{
+    "domain": "postini.com",
+    "mx_domains": [
+        "postini.com.s8a2.psmtp.com.",
+        "postini.com.s8b2.psmtp.com.",
+        "postini.com.s8b1.psmtp.com.",
+        "postini.com.s8a1.psmtp.com."
+    ],
+    "ns_records": [
+        "ns4.google.com.",
+        "ns1.google.com.",
+        "ns3.google.com.",
+        "ns2.google.com."
+    ]
+},
+{
+    "domain": "yahoo.com",
+    "mx_domains": [
+        "mta7.am0.yahoodns.net.",
+        "mta6.am0.yahoodns.net.",
+        "mta5.am0.yahoodns.net."
+    ],
+    "ns_records": [
+        "ns5.yahoo.com.",
+        "ns2.yahoo.com.",
+        "ns3.yahoo.com.",
+        "ns6.yahoo.com.",
+        "ns1.yahoo.com.",
+        "ns4.yahoo.com."
+    ]
+},
+{
+    "domain": "yahoo.se",
+    "mx_domains": [
+        "mx-eu.mail.am0.yahoodns.net."
+    ],
+    "ns_records": [
+        "ns5.yahoo.com.",
+        "ns2.yahoo.com.",
+        "ns1.yahoo.com.",
+        "ns4.yahoo.com.",
+        "ns3.yahoo.com."
+    ]
+},
+{
+    "domain": "hotmail.com",
+    "mx_domains": [
+        "mx2.hotmail.com.",
+        "mx3.hotmail.com.",
+        "mx4.hotmail.com.",
+        "mx1.hotmail.com."
+    ],
+    "ns_records": [
+        "ns2.msft.net.",
+        "ns3.msft.net.",
+        "ns4.msft.net.",
+        "ns1.msft.net."
+    ]
+},
+{
+    "domain": "outlook.com",
+    "mx_domains": [
+        "mx1.hotmail.com.",
+        "mx2.hotmail.com.",
+        "mx3.hotmail.com.",
+        "mx4.hotmail.com."
+    ],
+    "ns_records": [
+        "ns2.msft.net.",
+        "ns2a.o365filtering.com.",
+        "ns4a.o365filtering.com.",
+        "ns1a.o365filtering.com.",
+        "ns3.msft.net.",
+        "ns1.msft.net.",
+        "ns4.msft.net."
+    ]
+},
+{
+    "domain": "aol.com",
+    "mx_domains": [
+        "mailin-01.mx.aol.com.",
+        "mailin-04.mx.aol.com.",
+        "mailin-03.mx.aol.com.",
+        "mailin-02.mx.aol.com."
+    ],
+    "ns_records": [
+        "dns-01.ns.aol.com.",
+        "dns-07.ns.aol.com.",
+        "dns-02.ns.aol.com.",
+        "dns-06.ns.aol.com."
+    ]
+},
+{
+    "domain": "love.com",
+    "mx_domains": [
+        "mailin-03.mx.aol.com.",
+        "mailin-04.mx.aol.com.",
+        "mailin-01.mx.aol.com.",
+        "mailin-02.mx.aol.com."
+    ],
+    "ns_records": [
+        "dns-07.ns.aol.com.",
+        "dns-01.ns.aol.com.",
+        "dns-02.ns.aol.com.",
+        "dns-06.ns.aol.com."
+    ]
+},
+{
+    "domain": "games.com",
+    "mx_domains": [
+        "mailin-02.mx.aol.com.",
+        "mailin-03.mx.aol.com.",
+        "mailin-01.mx.aol.com.",
+        "mailin-04.mx.aol.com."
+    ],
+    "ns_records": [
+        "dns-06.ns.aol.com.",
+        "dns-02.ns.aol.com.",
+        "dns-07.ns.aol.com.",
+        "dns-01.ns.aol.com."
+    ]
+},
+{
+    "domain": "exchange.mit.edu",
+    "mx_domains": [
+        "mailsec-scanner-1.mit.edu.",
+        "mailsec-scanner-2.mit.edu.",
+        "mailsec-scanner-8.mit.edu.",
+        "mailsec-scanner-7.mit.edu.",
+        "mailsec-scanner-4.mit.edu.",
+        "mailsec-scanner-6.mit.edu.",
+        "mailsec-scanner-3.mit.edu.",
+        "mailsec-scanner-5.mit.edu."
+    ],
+    "ns_records": [
+        "use5.akam.net.",
+        "asia2.akam.net.",
+        "use2.akam.net.",
+        "eur5.akam.net.",
+        "usw2.akam.net.",
+        "ns1-173.akam.net.",
+        "ns1-37.akam.net.",
+        "asia1.akam.net."
+    ]
+},
+{
+    "domain": "fastmail.fm",
+    "mx_domains": [
+        "in2-smtp.messagingengine.com.",
+        "in1-smtp.messagingengine.com."
+    ],
+    "ns_records": [
+        "ns1.messagingengine.com.",
+        "ns2.messagingengine.com."
+    ]
+},
+{
+    "domain": "fastmail.net",
+    "mx_domains": [
+        "in1-smtp.messagingengine.com.",
+        "in2-smtp.messagingengine.com."
+    ],
+    "ns_records": [
+        "ns2.messagingengine.com.",
+        "ns1.messagingengine.com."
+    ]
+},
+{
+    "domain": "fastmail.com",
+    "mx_domains": [
+        "in2-smtp.messagingengine.com.",
+        "in1-smtp.messagingengine.com."
+    ],
+    "ns_records": [
+        "ns1.messagingengine.com.",
+        "ns2.messagingengine.com."
+    ]
+},
+{
+    "domain": "hover.com",
+    "mx_domains": [
+        "mx.hover.com.cust.hostedemail.com."
+    ],
+    "ns_records": [
+        "ns2.hover.com.",
+        "ns1.hover.com."
+    ]
+},
+{
+    "domain": "yahoo.com",
+    "mx_domains": [
+        "mta6.am0.yahoodns.net.",
+        "mta5.am0.yahoodns.net.",
+        "mta7.am0.yahoodns.net."
+    ],
+    "ns_records": [
+        "ns5.yahoo.com.",
+        "ns3.yahoo.com.",
+        "ns1.yahoo.com.",
+        "ns6.yahoo.com.",
+        "ns2.yahoo.com.",
+        "ns4.yahoo.com."
+    ]
+},
+{
+    "domain": "yandex.com",
+    "mx_domains": [
+        "mx.yandex.ru."
+    ],
+    "ns_records": [
+        "ns1.yandex.net.",
+        "ns2.yandex.net."
+    ]
+},
+{
+    "domain": "mrmail.com",
+    "mx_domains": [
+        "mx2.mrmail.com.",
+        "mx1.mrmail.com."
+    ],
+    "ns_records": [
+        "ns1.mrmail.com.",
+        "ns2.mrmail.com."
+    ]
+},
+{
+    "domain": "icloud.com",
+    "mx_domains": [
+        "mx6.mail.icloud.com.",
+        "mx5.mail.icloud.com.",
+        "mx4.mail.icloud.com.",
+        "mx3.mail.icloud.com.",
+        "mx2.mail.icloud.com.",
+        "mx1.mail.icloud.com."
+    ],
+    "ns_records": [
+        "adns2.apple.com.",
+        "adns1.apple.com.",
+        "nserver4.apple.com.",
+        "nserver.apple.com.",
+        "nserver3.apple.com.",
+        "nserver2.apple.com.",
+        "nserver6.apple.com.",
+        "nserver5.apple.com."
+    ]
+},
+{
+    "domain": "mac.com",
+    "mx_domains": [
+        "mx4.mail.icloud.com.",
+        "mx3.mail.icloud.com.",
+        "mx2.mail.icloud.com.",
+        "mx1.mail.icloud.com.",
+        "mx6.mail.icloud.com.",
+        "mx5.mail.icloud.com."
+    ],
+    "ns_records": [
+        "nserver2.apple.com.",
+        "nserver3.apple.com.",
+        "nserver.apple.com.",
+        "nserver4.apple.com.",
+        "adns2.apple.com.",
+        "adns1.apple.com.",
+        "nserver5.apple.com.",
+        "nserver6.apple.com."
+    ]
+},
+{
+    "domain": "gmx.com",
+    "mx_domains": [
+        "mx01.gmx.net.",
+        "mx00.gmx.net."
+    ],
+    "ns_records": [
+        "ns-gmx.ui-dns.org.",
+        "ns-gmx.ui-dns.de.",
+        "ns-gmx.ui-dns.biz.",
+        "ns-gmx.ui-dns.com."
+    ]
+},
+{
+    "domain": "gandi.net",
+    "mx_domains": [
+        "mail4.gandi.net.",
+        "mail8.gandi.net."
+    ],
+    "ns_records": [
+        "dns1.gandi.net.",
+        "dns3.gandi.net.",
+        "dns2.gandi.net.",
+        "dns0.gandi.net.",
+        "dns4.gandi.net."
+    ]
+},
+{
+    "domain": "debuggers.co",
+    "mx_domains": [],
+    "ns_records": []
+},
+{
+    "domain": "forumone.com",
+    "mx_domains": [
+        "alt2.aspmx.l.google.com.",
+        "alt1.aspmx.l.google.com.",
+        "alt3.aspmx.l.google.com.",
+        "alt4.aspmx.l.google.com.",
+        "aspmx.l.google.com."
+    ],
+    "ns_records": [
+        "ns2.forumone.com.",
+        "ns.forumone.com."
+    ]
+},
+{
+    "domain": "getbannerman.com",
+    "mx_domains": [
+        "aspmx.l.google.com.",
+        "alt1.aspmx.l.google.com.",
+        "alt2.aspmx.l.google.com.",
+        "aspmx2.googlemail.com.",
+        "aspmx3.googlemail.com."
+    ],
+    "ns_records": [
+        "ns-131.awsdns-16.com.",
+        "ns-1436.awsdns-51.org.",
+        "ns-1604.awsdns-08.co.uk.",
+        "ns-833.awsdns-40.net."
+    ]
+},
+{
+    "domain": "inboxapp.onmicrosoft.com",
+    "mx_domains": [],
+    "ns_records": [
+        "ns2.bdm.microsoftonline.com.",
+        "ns3.bdm.microsoftonline.com.",
+        "ns4.bdm.microsoftonline.com.",
+        "ns1.bdm.microsoftonline.com."
+    ]
+},
+{
+    "domain": "espertech.onmicrosoft.com",
+    "mx_domains": [
+        "espertech.mail.protection.outlook.com."
+    ],
+    "ns_records": [
+        "ns1.bdm.microsoftonline.com.",
+        "ns2.bdm.microsoftonline.com.",
+        "ns3.bdm.microsoftonline.com.",
+        "ns4.bdm.microsoftonline.com."
+    ]
+},
+{
+    "domain": "doesnotexist.nilas.com",
+    "mx_domains": [],
+    "ns_records": []
+},
+{
+    "domain": "autobizbrokers.com",
+    "mx_domains": [
+        "aspmx.l.google.com.",
+        "alt4.aspmx.l.google.com.",
+        "alt1.aspmx.l.google.com.",
+        "alt3.aspmx.l.google.com.",
+        "mail.autobizbrokers.com.",
+        "alt2.aspmx.l.google.com."
+    ],
+    "ns_records": [
+        "ns2.bluehost.com.",
+        "ns1.bluehost.com."
+    ]
+}]

--- a/tests/general/test_provider_resolution.py
+++ b/tests/general/test_provider_resolution.py
@@ -1,3 +1,5 @@
+import json
+import os
 import pytest
 from inbox.util.url import provider_from_address
 from inbox.util.url import InvalidEmailAddressError
@@ -6,45 +8,76 @@ from inbox.auth.generic import GenericAuthHandler
 from inbox.auth.gmail import GmailAuthHandler
 from inbox.basicauth import NotSupportedError
 
+class MockAnswer(object):
+    def __init__(self, exchange):
+        self.exchange = exchange
+
+    def __str__(self):
+        return self.exchange
+
+class MockDNSResolver(object):
+    def __init__(self, registry_filename):
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..',
+                            'data', registry_filename).encode('utf-8')
+        self.registry = {}
+        with open(path, 'r') as registry_file:
+            for entry in json.load(registry_file):
+                domain = entry['domain']
+                del entry['domain']
+                self.registry[domain] = entry
+
+    def query(self, domain, record_type):
+        if record_type == 'MX':
+            return [MockAnswer(entry) for entry in self.registry[domain]['mx_domains']]
+        if record_type == 'NS':
+            return [MockAnswer(entry) for entry in self.registry[domain]['ns_records']]
+        raise RuntimeError("Unsupported record type '%s'" % record_type)
+
 
 def test_provider_resolution():
-    assert provider_from_address('foo@example.com') == 'unknown'
-    assert provider_from_address('foo@noresolve.com') == 'unknown'
-    assert provider_from_address('foo@gmail.com') == 'gmail'
-    assert provider_from_address('foo@postini.com') == 'gmail'
-    assert provider_from_address('foo@yahoo.com') == 'yahoo'
-    assert provider_from_address('foo@yahoo.se') == 'yahoo'
-    assert provider_from_address('foo@hotmail.com') == 'outlook'
-    assert provider_from_address('foo@outlook.com') == 'outlook'
-    assert provider_from_address('foo@aol.com') == 'aol'
-    assert provider_from_address('foo@love.com') == 'aol'
-    assert provider_from_address('foo@games.com') == 'aol'
-    assert provider_from_address('foo@exchange.mit.edu') == 'eas'
-    assert provider_from_address('foo@fastmail.fm') == 'fastmail'
-    assert provider_from_address('foo@fastmail.net') == 'fastmail'
-    assert provider_from_address('foo@fastmail.com') == 'fastmail'
-    assert provider_from_address('foo@hover.com') == 'hover'
-    assert provider_from_address('foo@yahoo.com') == 'yahoo'
-    assert provider_from_address('foo@yandex.com') == 'yandex'
-    assert provider_from_address('foo@mrmail.com') == 'zimbra'
-    assert provider_from_address('foo@icloud.com') == 'icloud'
-    assert provider_from_address('foo@mac.com') == 'icloud'
-    assert provider_from_address('foo@gmx.com') == 'gmx'
-    assert provider_from_address('foo@gandi.net') == 'gandi'
-    assert provider_from_address('foo@debuggers.co') == 'gandi'
-    assert provider_from_address('foo@forumone.com') == 'gmail'
-    assert provider_from_address('foo@getbannerman.com') == 'gmail'
-    assert provider_from_address('foo@inboxapp.onmicrosoft.com') == 'eas'
-    assert provider_from_address('foo@espertech.onmicrosoft.com') == 'eas'
-    assert provider_from_address('foo@doesnotexist.nilas.com') == 'unknown'
-    assert provider_from_address('foo@autobizbrokers.com') == 'bluehost'
+    pfa = provider_from_address
+    dns_resolver = MockDNSResolver('dns.json')
+    test_cases = [
+        ('foo@example.com', 'unknown'),
+        ('foo@noresolve.com', 'unknown'),
+        ('foo@gmail.com', 'gmail'),
+        ('foo@postini.com', 'gmail'),
+        ('foo@yahoo.com', 'yahoo'),
+        ('foo@yahoo.se', 'yahoo'),
+        ('foo@hotmail.com', 'outlook'),
+        ('foo@outlook.com', 'outlook'),
+        ('foo@aol.com', 'aol'),
+        ('foo@love.com', 'aol'),
+        ('foo@games.com', 'aol'),
+        ('foo@exchange.mit.edu', 'eas'),
+        ('foo@fastmail.fm', 'fastmail'),
+        ('foo@fastmail.net', 'fastmail'),
+        ('foo@fastmail.com', 'fastmail'),
+        ('foo@hover.com', 'hover'),
+        ('foo@yahoo.com', 'yahoo'),
+        ('foo@yandex.com', 'yandex'),
+        ('foo@mrmail.com', 'zimbra'),
+        ('foo@icloud.com', 'icloud'),
+        ('foo@mac.com', 'icloud'),
+        ('foo@gmx.com', 'gmx'),
+        ('foo@gandi.net', 'gandi'),
+        ('foo@debuggers.co', 'gandi'),
+        ('foo@forumone.com', 'gmail'),
+        ('foo@getbannerman.com', 'gmail'),
+        ('foo@inboxapp.onmicrosoft.com', 'eas'),
+        ('foo@espertech.onmicrosoft.com', 'eas'),
+        ('foo@doesnotexist.nilas.com', 'unknown'),
+        ('foo@autobizbrokers.com', 'bluehost'),
+    ]
+    for email, expected_provider in test_cases:
+        assert provider_from_address(email, dns_resolver) == expected_provider
 
     with pytest.raises(InvalidEmailAddressError):
-        provider_from_address('notanemail')
+        provider_from_address('notanemail', dns_resolver)
     with pytest.raises(InvalidEmailAddressError):
-        provider_from_address('not@anemail')
+        provider_from_address('not@anemail', dns_resolver)
     with pytest.raises(InvalidEmailAddressError):
-        provider_from_address('notanemail.com')
+        provider_from_address('notanemail.com', dns_resolver)
 
 
 def test_auth_handler_dispatch():


### PR DESCRIPTION
Fixes #336 

Summary: This test previously depended on actually querying a DNS server which could
cause it to take an arbitrary amount of time depending on network conditions.
This diff mocks out the DNS resolver to do a lookup in a local dictionary
instead.

Test Plan: Run test, verify it works

Reviewers: spang bengotow
Please add the reviewer as an assignee to this PR on the right
