### PR TITLE
Speed up concurrency tests

### DIFF
--- a/tests/events/test_google_events.py
+++ b/tests/events/test_google_events.py
@@ -10,13 +10,6 @@ from inbox.models import Calendar, Event
 from inbox.models.event import RecurringEvent, RecurringEventOverride
 
 
-@pytest.yield_fixture
-def patched_gevent_sleep(monkeypatch):
-    monkeypatch.setattr('gevent.sleep', mock.Mock())
-    yield
-    monkeypatch.undo()
-
-
 def cmp_cal_attrs(calendar1, calendar2):
     return all(getattr(calendar1, attr) == getattr(calendar2, attr) for attr in
                ('name', 'uid', 'description', 'read_only'))
@@ -374,7 +367,8 @@ def test_handle_http_401():
     assert len(provider._get_access_token.mock_calls) == 2
 
 
-def test_handle_quota_exceeded(patched_gevent_sleep):
+@pytest.mark.usefixtures('mock_gevent_sleep')
+def test_handle_quota_exceeded():
     first_response = requests.Response()
     first_response.status_code = 403
     first_response._content = json.dumps({
@@ -404,7 +398,8 @@ def test_handle_quota_exceeded(patched_gevent_sleep):
     assert items == ['A', 'B', 'C']
 
 
-def test_handle_internal_server_error(patched_gevent_sleep):
+@pytest.mark.usefixtures('mock_gevent_sleep')
+def test_handle_internal_server_error():
     first_response = requests.Response()
     first_response.status_code = 503
 

--- a/tests/general/test_concurrency.py
+++ b/tests/general/test_concurrency.py
@@ -30,7 +30,7 @@ class FailingFunction(object):
             raise self.exc_type
         return
 
-
+@pytest.mark.usefixtures('mock_gevent_sleep')
 def test_retry_with_logging():
     logger = MockLogger()
     failing_function = FailingFunction(ValueError)

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -1,4 +1,5 @@
 import json
+import mock
 import os
 import uuid
 from datetime import datetime, timedelta
@@ -501,3 +502,10 @@ def add_fake_msg_with_calendar_part(db_session, account, ics_str, thread=None):
 
     assert msg.has_attached_events
     return msg
+
+
+@yield_fixture
+def mock_gevent_sleep(monkeypatch):
+    monkeypatch.setattr('gevent.sleep', mock.Mock())
+    yield
+    monkeypatch.undo()


### PR DESCRIPTION
Helps Issue #329 

Summary: This was just another case of a test sleeping for some long amount of time
during the test. We've also moved mock_gevent_sleep to be usable by all tests
via conftest.py.

Test Plan: Run tests

Reviewers: spang bengotow
Please add the reviewer as an assignee to this PR on the right
