### PR TITLE
remove `summary-stats` reference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
 
     scripts=['bin/inbox-start',
              'bin/inbox-console',
-             'bin/summary-stats',
              'bin/inbox-auth',
              'bin/delete-account-data',
              'bin/create-db',


### PR DESCRIPTION
Fixes `setup.py` again

Summary:
Hey @spang,

I just saw [that you removed the `summary-stats` script](https://github.com/nylas/sync-engine/commit/c99656df3c048faf7951e54d74cb5ef9d7dc3c97).
However, there is still a reference to it in the setup script which probably isn't intended. :wink: 

Have a wonderful day