### PR TITLE
Mock IMAPClient and SMTPClient for auth tests

### DIFF
--- a/tests/auth/test_generic_auth.py
+++ b/tests/auth/test_generic_auth.py
@@ -187,8 +187,8 @@ def test_update_account_when_no_server_provided(db):
     assert acc_smtp_port == smtp_port
 
 
-@pytest.mark.networkrequired
-def test_double_auth(db):
+@pytest.mark.usefixtures('mock_smtp_get_connection')
+def test_double_auth(db, mock_auth_imapclient):
     settings = {
         'provider': 'yahoo',
         'settings': {
@@ -199,6 +199,7 @@ def test_double_auth(db):
     }
     email = settings['settings']['email']
     password = settings['settings']['password']
+    mock_auth_imapclient._add_login(email, password)
 
     handler = GenericAuthHandler(settings['provider'])
 
@@ -250,8 +251,8 @@ def test_parent_domain():
     assert parent_domain('company.co.uk') != parent_domain('evilcompany.co.uk')
 
 
-@pytest.mark.networkrequired
-def test_successful_reauth_resets_sync_state(db):
+@pytest.mark.usefixtures('mock_smtp_get_connection')
+def test_successful_reauth_resets_sync_state(db, mock_auth_imapclient):
     settings = {
         'provider': 'yahoo',
         'settings': {
@@ -261,6 +262,8 @@ def test_successful_reauth_resets_sync_state(db):
             'password': 'EverybodyLovesIMAPv4'}
     }
     email = settings['settings']['email']
+    password = settings['settings']['password']
+    mock_auth_imapclient._add_login(email, password)
     handler = GenericAuthHandler(settings['provider'])
 
     account = handler.create_account(email, settings['settings'])

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -10,6 +10,7 @@ from hypothesis import strategies as s
 from hypothesis.extra.datetime import datetimes
 import flanker
 from flanker import mime
+from inbox.basicauth import ValidationError
 
 
 def _build_address_header(addresslist):
@@ -102,6 +103,23 @@ class MockIMAPClient(object):
         self._data = {}
         self.selected_folder = None
         self.uidvalidity = 1
+        self.logins = {}
+
+    def _add_login(self, email, password):
+        self.logins[email] = password
+
+    def login(self, email, password):
+        if email not in self.logins or self.logins[email] != password:
+            raise ValidationError
+
+    def logout(self):
+        pass
+
+    def list_folders(self, directory=u'', pattern=u'*'):
+        return []
+
+    def has_capability(self, capability):
+        return False
 
     def add_folder_data(self, folder_name, uids):
         """Adds fake UID data for the given folder."""

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import mock
 import os
@@ -8,6 +9,7 @@ from pytest import fixture, yield_fixture
 from flanker import mime
 
 from inbox.util.testutils import setup_test_db
+from tests.imap.data import MockIMAPClient
 
 
 def absolute_path(path):
@@ -509,3 +511,30 @@ def mock_gevent_sleep(monkeypatch):
     monkeypatch.setattr('gevent.sleep', mock.Mock())
     yield
     monkeypatch.undo()
+
+
+@fixture
+def mock_auth_imapclient(monkeypatch):
+    conn = MockIMAPClient()
+    monkeypatch.setattr(
+        'inbox.auth.generic.create_imap_connection',
+        lambda *args: conn
+    )
+    return conn
+
+
+class MockSMTPClient(object):
+    def __init__(self):
+        pass
+
+
+@fixture
+def mock_smtp_get_connection(monkeypatch):
+    client = MockSMTPClient()
+    @contextlib.contextmanager
+    def get_connection(account):
+        yield client
+    monkeypatch.setattr(
+        'inbox.sendmail.smtp.postel.SMTPClient._get_connection',
+        get_connection
+    )


### PR DESCRIPTION
Fixes #335 

Summary: The auth tests are slow because they run against live services. It isn't
necessary to test the underlying libraries we use to speak IMAP/SMTP, so we
should just mock them out so our tests run faster. Very unscientific tests
show this reducing our test running time by ~30 seconds on a laptop.

Test Plan: Run tests

Reviewers: spang bengotow
