### PR TITLE
TLS Improvements

### DIFF
--- a/inbox/config.py
+++ b/inbox/config.py
@@ -2,6 +2,18 @@ import errno
 import os
 import yaml
 
+# TODO[mike]: This should be removed once we've updated python to 2.7.9
+# This tells urllib3 to use pyopenssl, which has the latest tls protocols and is
+# more secure than the default python ssl module in python 2.7.4
+import urllib3.contrib.pyopenssl
+urllib3.contrib.pyopenssl.inject_into_urllib3()
+
+# TODO[mike]: This shold be removed once we've updated our base OS. openssl 1.0.1 doesn't support cross-signed certs
+# https://github.com/certifi/python-certifi/issues/26#issuecomment-138322515
+import certifi
+os.environ["REQUESTS_CA_BUNDLE"] = certifi.old_where()
+
+
 __all__ = ['config']
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,12 @@ boto==2.10.0
 ipython==1.0.0
 Flask==0.10.1
 freezegun==0.3.7
-gevent==1.0.1
+gevent==1.1.2
 gevent-socketio==0.3.5-rc2
 gunicorn==19.4.5
 mysqlclient==1.3.7
-requests==2.4.3
+requests==2.10.0
+urllib3[secure]>=1.16
 chardet==2.1.1
 setproctitle==1.1.8
 gdata==2.0.18


### PR DESCRIPTION
What this PR does:

- Updates requests
  - Various bugfixes
- Updates gevent
  - Has several SSL security updates and bugfixes
- adds urllib3[secure]
  - while this is included with and gets updated through requests, it’d be better to include it separately so we can get certifi updates more frequently rather than waiting on requests to put out a release
  - the secure extra installs certifi and other things we’ll need to verify HTTPS 
  - PyOpenSSL
    - Because we’re using python 2.7.4 we don’t have the latest ssl changes backported from python3. They were only added to 2.7.9, so until we can upgrade to that PyOpenSSL provides newer TLS protocol support and security improvements.
    - This is why we inject pyopenssl into urllib3
  - SNI Support
  - Certifi
    - Provides us with up to date root certificates that are bundled with Mozilla and ensures we can verify https 

Addresses `InsecurePlatformWarning` 

> Certain Python platforms (specifically, versions of Python earlier than 2.7.9) have restrictions in their `ssl` module that limit the configuration that `urllib3` can apply. In particular, this can cause HTTPS requests that would succeed on more featureful platforms to fail, and can cause certain security features to be unavailable.

Addresses `SNIMissingWarning` 

> Certain Python distributions (specifically, versions of Python earlier than 2.7.9) and older OpenSSLs have restrictions that prevent them from using the SNI (Server Name Indication) extension. This can cause unexpected behaviour when making some HTTPS requests, usually causing the server to present the a TLS certificate that is not valid for the website you’re trying to access.

We should be verifying HTTPS requests by default, because security. This will enable HTTPS verification by default, meaning we check that a server’s certificate is signed by a trusted certificate authority. 

Furthermore, it temporarily uses older, insecure, root certificates from mozilla (`old_where()`) to support cross-signed certificates until we can update to 2.7.9 or update openssl.

We still do not verify HTTPS requests for sync-engine-eas. We have a custom `HTTPAdapter` called `RetryHTTPAdapter` that does not do verification, probably because our customers are using self-signed certs. I’ve updated that adapter to use ssl.PROTOCOL_SSLV23 to ensure greatest compatibility. While eavesdroppers wouldn’t be able to listen in on the traffic, the connection is still susceptible to a MITM attack.