### PR TITLE
Only log repeated transient errors

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -234,7 +234,7 @@ class CrispinConnectionPool(object):
                                readonly=self.readonly)
 
 
-def _exc_callback():
+def _exc_callback(exc):
     log.info('Connection broken with error; retrying with new connection',
              exc_info=True)
     gevent.sleep(5)

--- a/inbox/instrumentation.py
+++ b/inbox/instrumentation.py
@@ -202,21 +202,21 @@ class GreenletTracer(object):
     def _monitoring_thread(self):
         # Logger needs to be instantiated in new thread.
         self.log = get_logger()
-        retry_with_logging(self._run_impl, self.log)
+        while True:
+            retry_with_logging(self._run_impl, self.log)
 
     def _run_impl(self):
         try:
-            while True:
-                self._calculate_pending_avgs()
-                self._calculate_cpu_avgs()
-                now = time.time()
-                if now - self.last_checked_blocking > self.max_blocking_time:
-                    self._check_blocking()
-                    self.last_checked_blocking = now
-                if now - self.last_logged_stats > self.logging_interval:
-                    self.log_stats()
-                    self.last_logged_stats = now
-                gevent.sleep(self.sampling_interval)
+            self._calculate_pending_avgs()
+            self._calculate_cpu_avgs()
+            now = time.time()
+            if now - self.last_checked_blocking > self.max_blocking_time:
+                self._check_blocking()
+                self.last_checked_blocking = now
+            if now - self.last_logged_stats > self.logging_interval:
+                self.log_stats()
+                self.last_logged_stats = now
+            gevent.sleep(self.sampling_interval)
         # Swallow exceptions raised during interpreter shutdown.
         except Exception:
             if sys is not None:

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -180,7 +180,7 @@ class FolderSyncEngine(Greenlet):
         self.heartbeat_status.publish()
 
         try:
-            self.saved_folder_status = self._load_state()
+            self.update_folder_sync_status(lambda s: s.start_sync())
         except IntegrityError:
             # The state insert failed because the folder ID ForeignKey
             # was no longer valid, ie. the folder for this engine was deleted
@@ -198,7 +198,6 @@ class FolderSyncEngine(Greenlet):
                                provider=self.provider_name, logger=log)
 
     def _run_impl(self):
-        saved_folder_status = self.saved_folder_status
         old_state = self.state
         try:
             self.state = self.state_handlers[old_state]()
@@ -243,42 +242,37 @@ class FolderSyncEngine(Greenlet):
         # State handlers are idempotent, so it's okay if we're
         # killed between the end of the handler and the commit.
         if self.state != old_state:
-            # Don't need to re-query, will auto refresh on re-associate.
-            with session_scope(self.namespace_id) as db_session:
-                db_session.add(saved_folder_status)
-                saved_folder_status.state = self.state
-                db_session.commit()
+            def update(status):
+                status.state = self.state
+            self.update_folder_sync_status(update)
 
         if self.state == old_state and self.state in ['initial', 'poll']:
             # We've been through a normal state transition without raising any
             # error. It's safe to reset the uidvalidity counter.
             self.uidinvalid_count = 0
 
-    def _load_state(self):
+    def update_folder_sync_status(self, cb):
+        # Loads the folder sync status and invokes the provided callback to
+        # modify it. Commits any changes and updates `self.state` to ensure
+        # they are never out of sync.
         with session_scope(self.namespace_id) as db_session:
             try:
                 state = ImapFolderSyncStatus.state
                 saved_folder_status = db_session.query(ImapFolderSyncStatus)\
-                    .filter_by(account_id=self.account_id,
-                               folder_id=self.folder_id).options(
-                        load_only(state)).one()
+                    .filter_by(account_id=self.account_id, folder_id=self.folder_id)\
+                    .options(load_only(state)).one()
             except NoResultFound:
                 saved_folder_status = ImapFolderSyncStatus(
                     account_id=self.account_id, folder_id=self.folder_id)
                 db_session.add(saved_folder_status)
 
-            saved_folder_status.start_sync()
-            db_session.commit()
+            cb(saved_folder_status)
+
             self.state = saved_folder_status.state
-            return saved_folder_status
+            db_session.commit()
 
     def set_stopped(self, db_session):
-        saved_folder_status = db_session.query(ImapFolderSyncStatus)\
-            .filter_by(account_id=self.account_id,
-                       folder_id=self.folder_id).one()
-
-        saved_folder_status.stop_sync()
-        self.state = saved_folder_status.state
+        self.update_folder_sync_status(lambda s: s.stop_sync())
 
     def _report_initial_sync_start(self):
         with session_scope(self.namespace_id) as db_session:

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -267,9 +267,9 @@ class FolderSyncEngine(Greenlet):
                 db_session.add(saved_folder_status)
 
             cb(saved_folder_status)
+            db_session.commit()
 
             self.state = saved_folder_status.state
-            db_session.commit()
 
     def set_stopped(self, db_session):
         self.update_folder_sync_status(lambda s: s.stop_sync())

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -178,12 +178,9 @@ class FolderSyncEngine(Greenlet):
                            provider=self.provider_name)
         # eagerly signal the sync status
         self.heartbeat_status.publish()
-        return retry_with_logging(self._run_impl, account_id=self.account_id,
-                                  provider=self.provider_name, logger=log)
 
-    def _run_impl(self):
         try:
-            saved_folder_status = self._load_state()
+            self.saved_folder_status = self._load_state()
         except IntegrityError:
             # The state insert failed because the folder ID ForeignKey
             # was no longer valid, ie. the folder for this engine was deleted
@@ -197,60 +194,65 @@ class FolderSyncEngine(Greenlet):
         # time if it receives a shutdown command. The shutdown command is
         # equivalent to ctrl-c.
         while True:
-            old_state = self.state
-            try:
-                self.state = self.state_handlers[old_state]()
-                self.heartbeat_status.publish(state=self.state)
-            except UidInvalid:
-                self.state = self.state + ' uidinvalid'
-                self.uidinvalid_count += 1
-                self.heartbeat_status.publish(state=self.state)
+            retry_with_logging(self._run_impl, account_id=self.account_id,
+                               provider=self.provider_name, logger=log)
 
-                # Check that we're not stuck in an endless uidinvalidity resync loop.
-                if self.uidinvalid_count > MAX_UIDINVALID_RESYNCS:
-                    log.error('Resynced more than MAX_UIDINVALID_RESYNCS in a'
-                              ' row. Stopping sync.')
+    def _run_impl(self):
+        saved_folder_status = self.saved_folder_status
+        old_state = self.state
+        try:
+            self.state = self.state_handlers[old_state]()
+            self.heartbeat_status.publish(state=self.state)
+        except UidInvalid:
+            self.state = self.state + ' uidinvalid'
+            self.uidinvalid_count += 1
+            self.heartbeat_status.publish(state=self.state)
 
-                    with session_scope(self.namespace_id) as db_session:
-                        account = db_session.query(Account).get(self.account_id)
-                        account.disable_sync('Detected endless uidvalidity '
-                                             'resync loop')
-                        account.sync_state = 'stopped'
-                        db_session.commit()
+            # Check that we're not stuck in an endless uidinvalidity resync loop.
+            if self.uidinvalid_count > MAX_UIDINVALID_RESYNCS:
+                log.error('Resynced more than MAX_UIDINVALID_RESYNCS in a'
+                          ' row. Stopping sync.')
 
-                    raise MailsyncDone()
-
-            except FolderMissingError:
-                # Folder was deleted by monitor while its sync was running.
-                # TODO: Monitor should handle shutting down the folder engine.
-                log.info('Folder disappeared. Stopping sync.',
-                         account_id=self.account_id,
-                         folder_name=self.folder_name,
-                         folder_id=self.folder_id)
-                raise MailsyncDone()
-            except ValidationError as exc:
-                log.error('Error authenticating; stopping sync', exc_info=True,
-                          account_id=self.account_id, folder_id=self.folder_id,
-                          logstash_tag='mark_invalid')
                 with session_scope(self.namespace_id) as db_session:
                     account = db_session.query(Account).get(self.account_id)
-                    account.mark_invalid()
-                    account.update_sync_error(str(exc))
-                raise MailsyncDone()
-
-            # State handlers are idempotent, so it's okay if we're
-            # killed between the end of the handler and the commit.
-            if self.state != old_state:
-                # Don't need to re-query, will auto refresh on re-associate.
-                with session_scope(self.namespace_id) as db_session:
-                    db_session.add(saved_folder_status)
-                    saved_folder_status.state = self.state
+                    account.disable_sync('Detected endless uidvalidity '
+                                         'resync loop')
+                    account.sync_state = 'stopped'
                     db_session.commit()
 
-            if self.state == old_state and self.state in ['initial', 'poll']:
-                # We've been through a normal state transition without raising any
-                # error. It's safe to reset the uidvalidity counter.
-                self.uidinvalid_count = 0
+                raise MailsyncDone()
+
+        except FolderMissingError:
+            # Folder was deleted by monitor while its sync was running.
+            # TODO: Monitor should handle shutting down the folder engine.
+            log.info('Folder disappeared. Stopping sync.',
+                     account_id=self.account_id,
+                     folder_name=self.folder_name,
+                     folder_id=self.folder_id)
+            raise MailsyncDone()
+        except ValidationError as exc:
+            log.error('Error authenticating; stopping sync', exc_info=True,
+                      account_id=self.account_id, folder_id=self.folder_id,
+                      logstash_tag='mark_invalid')
+            with session_scope(self.namespace_id) as db_session:
+                account = db_session.query(Account).get(self.account_id)
+                account.mark_invalid()
+                account.update_sync_error(str(exc))
+            raise MailsyncDone()
+
+        # State handlers are idempotent, so it's okay if we're
+        # killed between the end of the handler and the commit.
+        if self.state != old_state:
+            # Don't need to re-query, will auto refresh on re-associate.
+            with session_scope(self.namespace_id) as db_session:
+                db_session.add(saved_folder_status)
+                saved_folder_status.state = self.state
+                db_session.commit()
+
+        if self.state == old_state and self.state in ['initial', 'poll']:
+            # We've been through a normal state transition without raising any
+            # error. It's safe to reset the uidvalidity counter.
+            self.uidinvalid_count = 0
 
     def _load_state(self):
         with session_scope(self.namespace_id) as db_session:

--- a/inbox/mailsync/gc.py
+++ b/inbox/mailsync/gc.py
@@ -61,15 +61,15 @@ class DeleteHandler(gevent.Greenlet):
         gevent.Greenlet.__init__(self)
 
     def _run(self):
-        return retry_with_logging(self._run_impl, account_id=self.account_id,
-                                  provider=self.provider_name)
+        while True:
+            retry_with_logging(self._run_impl, account_id=self.account_id,
+                               provider=self.provider_name)
 
     def _run_impl(self):
-        while True:
-            current_time = datetime.datetime.utcnow()
-            self.check(current_time)
-            self.gc_deleted_categories()
-            gevent.sleep(self.message_ttl.total_seconds())
+        current_time = datetime.datetime.utcnow()
+        self.check(current_time)
+        self.gc_deleted_categories()
+        gevent.sleep(self.message_ttl.total_seconds())
 
     def check(self, current_time):
         with session_scope(self.namespace_id) as db_session:

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -86,16 +86,16 @@ class SyncService(object):
             self.rolling_cpu_counts.append(null_cpu_values)
 
     def run(self):
-        retry_with_logging(self._run_impl, self.log)
+        while True:
+            retry_with_logging(self._run_impl, self.log)
 
     def _run_impl(self):
         """
         Polls for newly registered accounts and checks for start/stop commands.
 
         """
-        while True:
-            self.poll()
-            gevent.sleep(self.poll_interval)
+        self.poll()
+        gevent.sleep(self.poll_interval)
 
     def _compute_cpu_average(self):
         """

--- a/inbox/scheduling/queue.py
+++ b/inbox/scheduling/queue.py
@@ -140,18 +140,18 @@ class QueuePopulator(object):
                                    if shard_id in engine_manager.engines)
 
     def run(self):
-        return retry_with_logging(self._run_impl)
-
-    def _run_impl(self):
         log.info('Queueing accounts', zone=self.zone, shards=self.shards)
         while True:
-            self.enqueue_new_accounts()
-            self.unassign_disabled_accounts()
-            statsd_client.gauge('syncqueue.queue.{}.length'.format(self.zone),
-                                self.queue_client.qsize())
-            statsd_client.incr('syncqueue.service.{}.heartbeat'.
-                               format(self.zone))
-            gevent.sleep(self.poll_interval)
+            retry_with_logging(self._run_impl)
+
+    def _run_impl(self):
+        self.enqueue_new_accounts()
+        self.unassign_disabled_accounts()
+        statsd_client.gauge('syncqueue.queue.{}.length'.format(self.zone),
+                            self.queue_client.qsize())
+        statsd_client.incr('syncqueue.service.{}.heartbeat'.
+                           format(self.zone))
+        gevent.sleep(self.poll_interval)
 
     def enqueue_new_accounts(self):
         """

--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -47,22 +47,11 @@ class BaseSyncMonitor(Greenlet):
     def _run(self):
         # Bind greenlet-local logging context.
         self.log = self.log.new(account_id=self.account_id)
-        return retry_with_logging(self._run_impl, account_id=self.account_id,
-                                  provider=self.provider_name, logger=self.log)
-
-    def _run_impl(self):
         try:
             while True:
-                try:
-                    self.sync()
-                    self.heartbeat_status.publish(state='poll')
-
-                # If we get a connection or API permissions error, then sleep
-                # 2x poll frequency.
-                except ConnectionError:
-                    self.log.error('Error while polling', exc_info=True)
-                    sleep(self.poll_frequency)
-                sleep(self.poll_frequency)
+                retry_with_logging(self._run_impl, account_id=self.account_id,
+                                   fail_classes=(ValidationError),
+                                   provider=self.provider_name, logger=self.log)
         except ValidationError:
             # Bad account credentials; exit.
             self.log.error('Credential validation error; exiting',
@@ -70,6 +59,18 @@ class BaseSyncMonitor(Greenlet):
             with session_scope(self.namespace_id) as db_session:
                 account = db_session.query(Account).get(self.account_id)
                 account.mark_invalid(scope=self.scope)
+
+    def _run_impl(self):
+        try:
+            self.sync()
+            self.heartbeat_status.publish(state='poll')
+
+        # If we get a connection or API permissions error, then sleep
+        # 2x poll frequency.
+        except ConnectionError:
+            self.log.error('Error while polling', exc_info=True)
+            sleep(self.poll_frequency)
+        sleep(self.poll_frequency)
 
     def sync(self):
         """ Subclasses should override this to do work """

--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -50,7 +50,7 @@ class BaseSyncMonitor(Greenlet):
         try:
             while True:
                 retry_with_logging(self._run_impl, account_id=self.account_id,
-                                   fail_classes=(ValidationError),
+                                   fail_classes=[ValidationError],
                                    provider=self.provider_name, logger=self.log)
         except ValidationError:
             # Bad account credentials; exit.

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -252,27 +252,27 @@ class SyncbackService(gevent.Greenlet):
             worker.start()
 
     def _run_impl(self):
-        self.log.info('Starting syncback service',
-                      process_num=self.process_number,
-                      total_processes=self.total_processes,
-                      keys=self.keys)
-        while self.keep_running:
-            self._restart_workers()
-            self._process_log()
-            # Wait for a worker to finish or for the fixed poll_interval,
-            # whichever happens first.
-            timeout = self.poll_interval
-            if self.num_idle_workers == 0:
-                timeout = None
-            self.worker_did_finish.clear()
-            self.worker_did_finish.wait(timeout=timeout)
+        self._restart_workers()
+        self._process_log()
+        # Wait for a worker to finish or for the fixed poll_interval,
+        # whichever happens first.
+        timeout = self.poll_interval
+        if self.num_idle_workers == 0:
+            timeout = None
+        self.worker_did_finish.clear()
+        self.worker_did_finish.wait(timeout=timeout)
 
     def stop(self):
         self.keep_running = False
         self.workers.kill()
 
     def _run(self):
-        retry_with_logging(self._run_impl, self.log)
+        self.log.info('Starting syncback service',
+                      process_num=self.process_number,
+                      total_processes=self.total_processes,
+                      keys=self.keys)
+        while self.keep_running:
+            retry_with_logging(self._run_impl, self.log)
 
     def notify_worker_active(self):
         self.num_idle_workers -= 1

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -24,8 +24,8 @@ def retry(func, retry_classes=None, fail_classes=None, exc_callback=None,
     ---------
     func : function
     exc_callback : function, optional
-        Function to execute if an exception is raised within func
-        (e.g., log something)
+        Function to execute if an exception is raised within func. The exception
+        is passed as the first argument. (e.g., log something)
     retry_classes: list of Exception subclasses, optional
         Configures what to retry on. If specified, func is retried only if one
         of these exceptions is raised. Default is to retry on all exceptions.

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -4,13 +4,14 @@ import random
 import gevent
 from backports import ssl
 from gevent import socket
+from redis import TimeoutError
 
 from nylas.logging import get_logger
 from nylas.logging.sentry import log_uncaught_errors
 log = get_logger()
 
 BACKOFF_DELAY = 30  # seconds to wait before retrying after a failure
-TRANSIENT_NETWORK_ERRS = (socket.timeout, socket.error, ssl.SSLError)
+TRANSIENT_NETWORK_ERRS = (socket.timeout, TimeoutError, socket.error, ssl.SSLError)
 
 
 def retry(func, retry_classes=None, fail_classes=None, exc_callback=None,

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -2,17 +2,22 @@ import functools
 import random
 
 import gevent
+from backports import ssl
+from gevent import socket
 
 from nylas.logging import get_logger
 from nylas.logging.sentry import log_uncaught_errors
 log = get_logger()
+
 BACKOFF_DELAY = 30  # seconds to wait before retrying after a failure
+TRANSIENT_NETWORK_ERRS = (socket.timeout, socket.error, ssl.SSLError)
 
 
 def retry(func, retry_classes=None, fail_classes=None, exc_callback=None,
           backoff_delay=BACKOFF_DELAY):
     """
-    Executes the callable func, retrying on uncaught exceptions.
+    Executes the callable func, retrying on uncaught exceptions matching the
+    class filters.
 
     Arguments
     ---------
@@ -53,7 +58,7 @@ def retry(func, retry_classes=None, fail_classes=None, exc_callback=None,
                 if not should_retry_on(e):
                     raise
                 if exc_callback is not None:
-                    exc_callback()
+                    exc_callback(e)
 
             # Sleep a bit so that we don't poll too quickly and re-encounter
             # the error. Also add a random delay to prevent herding effects.
@@ -65,8 +70,17 @@ def retry(func, retry_classes=None, fail_classes=None, exc_callback=None,
 def retry_with_logging(func, logger=None, retry_classes=None,
                        fail_classes=None, account_id=None, provider=None,
                        backoff_delay=BACKOFF_DELAY):
-    def callback():
-        log_uncaught_errors(logger, account_id=account_id, provider=provider)
+    network_errs = [0]
+
+    def callback(e):
+        if isinstance(e, TRANSIENT_NETWORK_ERRS):
+            network_errs[0] += 1
+            if network_errs[0] < 20:
+                return
+        else:
+            network_errs[0] = 0
+        log_uncaught_errors(logger, account_id=account_id, provider=provider,
+                            error_type=type(e).__name__)
 
     return retry(func, exc_callback=callback, retry_classes=retry_classes,
                  fail_classes=fail_classes, backoff_delay=backoff_delay)()

--- a/tests/general/test_concurrency.py
+++ b/tests/general/test_concurrency.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 from gevent import GreenletExit
+from gevent import socket
 
 from inbox.util.concurrency import retry_with_logging
 
@@ -56,3 +57,20 @@ def test_selective_retry():
                            fail_classes=[ValueError])
     assert logger.call_count == 0
     assert failing_function.call_count == 1
+
+
+@pytest.mark.usefixtures('mock_gevent_sleep')
+def test_no_logging_until_many_transient_error():
+    logger = MockLogger()
+
+    failing_function = FailingFunction(socket.error, max_executions=2)
+    retry_with_logging(failing_function, logger=logger)
+
+    assert logger.call_count == 0
+    assert failing_function.call_count == 2
+
+    failing_function = FailingFunction(socket.error, max_executions=21)
+    retry_with_logging(failing_function, logger=logger)
+
+    assert logger.call_count == 1
+    assert failing_function.call_count == 21

--- a/tests/general/test_sync_engine_exit.py
+++ b/tests/general/test_sync_engine_exit.py
@@ -49,7 +49,7 @@ def test_folder_engine_exits_if_folder_missing(db, yahoo_account,
     db.session.delete(folder)
     db.session.commit()
     with pytest.raises(IntegrityError):
-        sync_engine_stub._load_state()
+        sync_engine_stub.update_folder_sync_status(lambda s: s)
 
     # and we should use this to signal that mailsync is done
     with pytest.raises(MailsyncDone):

--- a/tests/imap/test_folder_sync.py
+++ b/tests/imap/test_folder_sync.py
@@ -215,7 +215,7 @@ def test_handle_uidinvalid_loops(db, generic_account, inbox_folder,
     db.session.expunge(inbox_folder.imapsyncstatus)
 
     with pytest.raises(MailsyncDone):
-        folder_sync_engine._run_impl()
+        folder_sync_engine._run()
 
     assert len(uidinvalid_count) == MAX_UIDINVALID_RESYNCS + 1
 


### PR DESCRIPTION
We use a function `retry_with_logging` in a bunch of places to retry indefinitely when errors occur. In the long run, I want to make this function behave differently (catch specific sets of known transient errors and raise the rest to stop the sync.) This patch is the first step toward that.

retry_with_logging only reports transient errors to Sentry / logs if they occur 20+ times in a row. (If this turns out to be a good threshold, we'll see almost none of these network errors being reported anymore.)

In order to make this work, I had to restructure a bunch of places that use retry_with_logging like this:

```
retry_with_logging =>
   while true
       // do things
```

to

```
while true
    retry_with_logging
        // do things
```

This is necessary because retry_with_logging only saw a series of exceptions, potentially transient network errors over the course of 24 hours. By putting the `while true` outside it, the error counter can be reset every time the loop runs successfully.