### PR TITLE
Fix a couple sleeping tests with freezegun

### DIFF
--- a/tests/transactions/test_delta_sync.py
+++ b/tests/transactions/test_delta_sync.py
@@ -1,5 +1,7 @@
+import datetime
 import json
 import time
+from freezegun import freeze_time
 from tests.util.base import add_fake_message
 from tests.api.base import api_client
 
@@ -31,14 +33,15 @@ def get_cursor(api_client, timestamp):
 
 
 def test_latest_cursor(api_client):
-    time.sleep(5)
-    now = int(time.time())
+    with freeze_time(datetime.datetime.utcnow()) as freezer:
+        freezer.tick(datetime.timedelta(seconds=5))
+        now = int(time.time())
 
-    latest_cursor_resp = api_client.post_raw('/delta/latest_cursor', None)
-    latest_cursor = json.loads(latest_cursor_resp.data)['cursor']
+        latest_cursor_resp = api_client.post_raw('/delta/latest_cursor', None)
+        latest_cursor = json.loads(latest_cursor_resp.data)['cursor']
 
-    now_cursor = get_cursor(api_client, now)
-    assert latest_cursor == now_cursor
+        now_cursor = get_cursor(api_client, now)
+        assert latest_cursor == now_cursor
 
 
 def test_invalid_input(api_client):


### PR DESCRIPTION
Summary: Freezegun allows us to directly manipulate what time our tests think it is. So
now we don't have to actually sleep to get the clock the move forward :-D

Test Plan: Run the tests

Reviewers: spang bengotow