### PR TITLE
Add timestamps to setup.sh output for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 cache:
   directories:
-    - /usr/local/lib/python2.7/dist-packages
     - /home/travis/virtualenv
 before_install:
   - mysql -uroot -Dmysql -e 'UPDATE user SET password=PASSWORD("root") WHERE user="root"; FLUSH PRIVILEGES;'
 install:
   - sudo -H pip install flake8
-  - sudo -H ./setup.sh
+  - sudo -H ./setup.sh | awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush(); }'
 script:
   - flake8 --select=F inbox
   - pylint -d all -e w0631 inbox


### PR DESCRIPTION
Summary: This will be helpful to analyze which parts of the Travis build are taking the longest. This also removes the /usr/local/lib/python2.7/dist-packages from the cache settings in Travis config file because it was causing the cache step to take > 3 minutes and then time out. By not trying to cache this directory we save those 3 minutes of build time.

Test Plan: Wait for Travis to run, look at the output

Reviewers: spang bengotow