### PR TITLE
Fix event parsing to support missing “LAST-MODIFIED”

### DIFF
--- a/inbox/events/ical.py
+++ b/inbox/events/ical.py
@@ -101,25 +101,25 @@ def events_from_ics(namespace, calendar, ics_str):
 
             # Get the last modification date.
             # Exchange uses DtStamp, iCloud and Gmail LAST-MODIFIED.
-            last_modified_tstamp = component.get('dtstamp')
+            component_dtstamp = component.get('dtstamp')
+            component_last_modified = component.get('last-modified')
             last_modified = None
-            if last_modified_tstamp is not None:
+
+            if component_dtstamp is not None:
                 # This is one surprising instance of Exchange doing
                 # the right thing by giving us an UTC timestamp. Also note that
                 # Google calendar also include the DtStamp field, probably to
                 # be a good citizen.
-                if last_modified_tstamp.dt.tzinfo is not None:
-                    last_modified = last_modified_tstamp.dt
+                if component_dtstamp.dt.tzinfo is not None:
+                    last_modified = component_dtstamp.dt
                 else:
                     raise NotImplementedError("We don't support arcane Windows"
                                               " timezones in timestamps yet")
-            else:
+            elif component_last_modified is not None:
                 # Try to look for a LAST-MODIFIED element instead.
                 # Note: LAST-MODIFIED is always in UTC.
                 # http://www.kanzaki.com/docs/ical/lastModified.html
-                last_modified = component.get('last-modified').dt
-                assert last_modified is not None, \
-                    "Event should have a DtStamp or LAST-MODIFIED timestamp"
+                last_modified = component_last_modified.dt
 
             title = None
             summaries = component.get('summary', [])


### PR DESCRIPTION
I have a bunch of event invites sent from UberConference in my account. They do not have DTSTAMP or LAST-MODIFIED. Our Events table supports null values in that column, so I think we should allow them to be parsed and not blow up.

The exception this fixes is below:

{"traceback": ["Traceback (most recent call last):\n", "  File \"/vagrant/inbox/events/ical.py\", line 391, in import_attached_events\n    part_data)\n", "  File \"/vagrant/inbox/events/ical.py\", line 120, in events_from_ics\n    last_modified = component.get('last-modified').dt\n", "AttributeError: 'NoneType' object has no attribute 'dt'\n"], "account_id": 7, "level": "error", "timestamp": "2016-08-04T23:51:18.138445Z", "greenlet_id": 74350096, "module": "inbox.events.ical:410", "event": "Unhandled exception during message parsing", "state": "initial", "provider": "gmail", "folder": "[Gmail]/All Mail", "logstash_tag": "icalendar_autoimport", "message_id": 89225, "invite": “…