### PR TITLE
Rewrite filename trunction to handle UTF8 correctly, add test

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -44,7 +44,10 @@ def _trim_filename(s, namespace_id, max_len=255):
     if len(s) > max_len:
         # If we need to truncate the string, keep the extension
         filename, fileext = os.path.splitext(s)
-        return filename[:(max_len - len(fileext))] + fileext
+        if len(fileext) < max_len - 1:
+            return filename[:(max_len - len(fileext))] + fileext
+        else:
+            return filename[0] + fileext[:(max_len - 1)]
 
     return s
 

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -1,3 +1,4 @@
+import os
 import binascii
 import datetime
 import itertools
@@ -30,12 +31,21 @@ from inbox.models.category import Category
 from inbox.sqlalchemy_ext.util import MAX_MYSQL_INTEGER
 
 
-def _trim_filename(s, namespace_id, max_len=64):
-    if s and len(s) > max_len:
-        log.warning('filename is too long, truncating',
-                    max_len=max_len, filename=s,
-                    namespace_id=namespace_id)
-        return s[:max_len - 8] + s[-8:]  # Keep extension
+def _trim_filename(s, namespace_id, max_len=255):
+    # The filename may be up to 255 4-byte unicode characters. If the
+    # filename is longer than that, truncate it appropriately.
+
+    # If `s` is not stored as a unicode string, but contains unicode
+    # characters, len will return the wrong value (bytes not chars).
+    # Convert it to unicode first.
+    if not isinstance(s, unicode):
+        s = s.decode('utf-8', 'ignore')
+
+    if len(s) > max_len:
+        # If we need to truncate the string, keep the extension
+        filename, fileext = os.path.splitext(s)
+        return filename[:(max_len - len(fileext))] + fileext
+
     return s
 
 

--- a/tests/general/test_filename_truncation.py
+++ b/tests/general/test_filename_truncation.py
@@ -16,3 +16,9 @@ def test_filename_truncation():
     assert _trim_filename(cname, 'a', max_len=7) == u'\U0001f1fa\U0001f1f8\u2678.txt'
     assert _trim_filename(cname, 'a', max_len=6) == u'\U0001f1fa\U0001f1f8.txt'
     assert _trim_filename(cname, 'a', max_len=5) == u'\U0001f1fa.txt'
+
+    uname = 'ABCDEF.txttxttxtxtxttxttxtx'
+    assert _trim_filename(uname, 'a', max_len=8) == 'A.txttxt'
+
+    uname = '.txttxttxtxtxttxttxtx'
+    assert _trim_filename(uname, 'a', max_len=8) == '.txttxtt'

--- a/tests/general/test_filename_truncation.py
+++ b/tests/general/test_filename_truncation.py
@@ -1,0 +1,18 @@
+from inbox.models.message import _trim_filename
+
+
+def test_filename_truncation():
+    # Note: test both 3-byte and 4-byte UTF8 chars to make sure truncation
+    # follows UTF8 boundaries.
+    uname = u'\U0001f1fa\U0001f1f8\u2678\U0001f602.txt'
+    assert _trim_filename(uname, 'a', max_len=8) == uname
+    assert _trim_filename(uname, 'a', max_len=7) == u'\U0001f1fa\U0001f1f8\u2678.txt'
+    assert _trim_filename(uname, 'a', max_len=6) == u'\U0001f1fa\U0001f1f8.txt'
+    assert _trim_filename(uname, 'a', max_len=5) == u'\U0001f1fa.txt'
+
+    # Note: Test input that is not unicode, ensure it uses unicode length not byte length
+    cname = '\xf0\x9f\x87\xba\xf0\x9f\x87\xb8\xe2\x99\xb8\xf0\x9f\x98\x82.txt'
+    assert _trim_filename(cname, 'a', max_len=8) == uname
+    assert _trim_filename(cname, 'a', max_len=7) == u'\U0001f1fa\U0001f1f8\u2678.txt'
+    assert _trim_filename(cname, 'a', max_len=6) == u'\U0001f1fa\U0001f1f8.txt'
+    assert _trim_filename(cname, 'a', max_len=5) == u'\U0001f1fa.txt'


### PR DESCRIPTION
Based on Slack conversation here: https://nylas.slack.com/archives/sync/p1470352819000868, and observation that our filename column can actually support 255 4-byte UTF8 strings just fine (https://dev.mysql.com/doc/refman/5.6/en/charset-unicode-utf8mb4.html). Seems we've been truncating filenames unnecessarily for a while.

Sidenote: I'm totally new to Python 2's handling of unicode, so this might be totally borked, but the test seems to work...