### PR TITLE
Make sure queries by name to Folder/Label/Category account for truncation

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -85,7 +85,6 @@ from inbox.models import Folder, Account, Message
 from inbox.models.backends.imap import (ImapFolderSyncStatus, ImapThread,
                                         ImapUid, ImapFolderInfo)
 from inbox.models.session import session_scope
-from inbox.models.constants import MAX_FOLDER_NAME_LENGTH
 from inbox.mailsync.backends.imap import common
 from inbox.mailsync.backends.base import (MailsyncDone, MailsyncError,
                                           THROTTLE_COUNT, THROTTLE_WAIT)
@@ -119,10 +118,8 @@ class FolderSyncEngine(Greenlet):
 
         with session_scope(namespace_id) as db_session:
             try:
-                folder_stored_name = folder_name\
-                    .rstrip()[:MAX_FOLDER_NAME_LENGTH]
                 folder = db_session.query(Folder). \
-                    filter(Folder.name == folder_stored_name,
+                    filter(Folder.name == folder_name,
                            Folder.account_id == account_id).one()
             except NoResultFound:
                 raise MailsyncError(u"Missing Folder '{}' on account {}"

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -85,6 +85,7 @@ from inbox.models import Folder, Account, Message
 from inbox.models.backends.imap import (ImapFolderSyncStatus, ImapThread,
                                         ImapUid, ImapFolderInfo)
 from inbox.models.session import session_scope
+from inbox.models.constants import MAX_FOLDER_NAME_LENGTH
 from inbox.mailsync.backends.imap import common
 from inbox.mailsync.backends.base import (MailsyncDone, MailsyncError,
                                           THROTTLE_COUNT, THROTTLE_WAIT)
@@ -118,8 +119,10 @@ class FolderSyncEngine(Greenlet):
 
         with session_scope(namespace_id) as db_session:
             try:
+                folder_stored_name = folder_name\
+                    .rstrip()[:MAX_FOLDER_NAME_LENGTH]
                 folder = db_session.query(Folder). \
-                    filter(Folder.name == folder_name,
+                    filter(Folder.name == folder_stored_name,
                            Folder.account_id == account_id).one()
             except NoResultFound:
                 raise MailsyncError(u"Missing Folder '{}' on account {}"

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -77,7 +77,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
 
         """
         account = db_session.query(Account).get(self.account_id)
-        remote_folder_names = {f.display_name.rstrip()[:MAX_FOLDER_NAME_LENGTH]
+        remote_folder_names = {Category.sanitize_name(f.display_name)
                                for f in raw_folders}
 
         assert 'inbox' in {f.role for f in raw_folders},\

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -5,7 +5,6 @@ from inbox.basicauth import ValidationError
 from nylas.logging import get_logger
 from inbox.crispin import retry_crispin, connection_pool
 from inbox.models import Account, Folder, Category
-from inbox.models.constants import MAX_FOLDER_NAME_LENGTH
 from inbox.models.session import session_scope
 from inbox.mailsync.backends.base import BaseMailSyncMonitor
 from inbox.mailsync.backends.imap.generic import FolderSyncEngine

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -4,7 +4,8 @@ from gevent.coros import BoundedSemaphore
 from inbox.basicauth import ValidationError
 from nylas.logging import get_logger
 from inbox.crispin import retry_crispin, connection_pool
-from inbox.models import Account, Folder, Category
+from inbox.models import Account, Folder
+from inbox.models.category import Category, sanitize_name
 from inbox.models.session import session_scope
 from inbox.mailsync.backends.base import BaseMailSyncMonitor
 from inbox.mailsync.backends.imap.generic import FolderSyncEngine
@@ -76,7 +77,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
 
         """
         account = db_session.query(Account).get(self.account_id)
-        remote_folder_names = {Category.sanitize_name(f.display_name)
+        remote_folder_names = {sanitize_name(f.display_name)
                                for f in raw_folders}
 
         assert 'inbox' in {f.role for f in raw_folders},\

--- a/inbox/models/category.py
+++ b/inbox/models/category.py
@@ -19,7 +19,7 @@ log = get_logger()
 EPOCH = datetime.utcfromtimestamp(0)
 
 
-class CategoryNameType(String):
+class CategoryNameString(String):
     """
     Column type that extends the sqlalchemy.String to extend its `==`
     comparator for category (Folder/Label/Category) names.
@@ -28,6 +28,10 @@ class CategoryNameType(String):
     ensure that the input of any `==` queries executed against a Column of this
     type match the values that we are actually storing in the database.
     """
+
+    def __init__(self, *args, **kwargs):
+        super(CategoryNameString, self).__init__(MAX_INDEXABLE_LENGTH,
+                                                 collation='utf8mb4_bin')
 
     class comparator_factory(String.Comparator):
         def __eq__(self, other):
@@ -56,8 +60,7 @@ class Category(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin,
 
     # STOPSHIP(emfree): need to index properly for API filtering performance.
     name = Column(String(MAX_INDEXABLE_LENGTH), nullable=False, default='')
-    display_name = Column(CategoryNameType(MAX_INDEXABLE_LENGTH,
-                          collation='utf8mb4_bin'), nullable=False)
+    display_name = Column(CategoryNameString(), nullable=False)
 
     type_ = Column(Enum('folder', 'label'), nullable=False, default='folder')
 

--- a/inbox/models/category.py
+++ b/inbox/models/category.py
@@ -20,6 +20,14 @@ EPOCH = datetime.utcfromtimestamp(0)
 
 
 class CategoryNameType(String):
+    """
+    Column type that extends the sqlalchemy.String to extend its `==`
+    comparator for category (Folder/Label/Category) names.
+
+    We store rstripped and truncated category names, so this class will
+    ensure that the input of any `==` queries executed against a Column of this
+    type match the values that we are actually storing in the database.
+    """
 
     class comparator_factory(String.Comparator):
         def __eq__(self, other):

--- a/inbox/models/category.py
+++ b/inbox/models/category.py
@@ -58,7 +58,7 @@ class Category(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin,
         sanitized_name = Category.sanitize_name(display_name)
         if sanitized_name != display_name:
             log.warning("Truncating category display_name", type_=self.type_,
-                        account_id=self.account_id, original=display_name)
+                        original=display_name)
         return sanitized_name
 
     @classmethod

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from inbox.models.base import MailSyncBase
 from inbox.models.category import Category, CategoryNameType
 from inbox.models.mixins import UpdatedAtMixin, DeletedAtMixin
-from inbox.models.constants import MAX_FOLDER_NAME_LENGTH
+from inbox.models.constants import MAX_INDEXABLE_LENGTH
 from inbox.sqlalchemy_ext.util import bakery
 from nylas.logging import get_logger
 log = get_logger()
@@ -36,9 +36,9 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
     # NOTE: this doesn't hold for EAS, which is case insensitive for non-Inbox
     # folders as per
     # https://msdn.microsoft.com/en-us/library/ee624913(v=exchg.80).aspx
-    name = Column(CategoryNameType(MAX_FOLDER_NAME_LENGTH,
+    name = Column(CategoryNameType(MAX_INDEXABLE_LENGTH,
                   collation='utf8mb4_bin'), nullable=False)
-    canonical_name = Column(String(MAX_FOLDER_NAME_LENGTH), nullable=False,
+    canonical_name = Column(String(MAX_INDEXABLE_LENGTH), nullable=False,
                             default='')
 
     category_id = Column(ForeignKey(Category.id, ondelete='CASCADE'))

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -4,7 +4,7 @@ from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from inbox.models.base import MailSyncBase
-from inbox.models.category import Category
+from inbox.models.category import Category, CategoryNameType
 from inbox.models.mixins import UpdatedAtMixin, DeletedAtMixin
 from inbox.models.constants import MAX_FOLDER_NAME_LENGTH
 from inbox.sqlalchemy_ext.util import bakery
@@ -36,8 +36,8 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
     # NOTE: this doesn't hold for EAS, which is case insensitive for non-Inbox
     # folders as per
     # https://msdn.microsoft.com/en-us/library/ee624913(v=exchg.80).aspx
-    name = Column(String(MAX_FOLDER_NAME_LENGTH, collation='utf8mb4_bin'),
-                  nullable=False)
+    name = Column(CategoryNameType(MAX_FOLDER_NAME_LENGTH,
+                  collation='utf8mb4_bin'), nullable=False)
     canonical_name = Column(String(MAX_FOLDER_NAME_LENGTH), nullable=False,
                             default='')
 
@@ -51,26 +51,17 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
     initial_sync_end = Column(DateTime, nullable=True)
 
     @validates('name')
-    def sanitize_name(self, key, name):
-        name = name.rstrip()
-        if len(name) > MAX_FOLDER_NAME_LENGTH:
-            log.warning("Truncating folder name for account {}; original name "
-                        "was '{}'".format(self.account_id, name))
-            name = name[:MAX_FOLDER_NAME_LENGTH]
-        return name
+    def validate_name(self, key, name):
+        sanitized_name = Category.sanitize_name(name)
+        if sanitized_name != name:
+            log.warning("Truncating folder name for account",
+                        account_id=self.account_id, name=name)
+        return sanitized_name
 
     @classmethod
     def find_or_create(cls, session, account, name, role=None):
-        q = session.query(cls).filter(cls.account_id == account.id)
-
-        # Remove trailing whitespace, truncate to max folder name length.
-        # Not ideal but necessary to work around MySQL limitations.
-        name = name.rstrip()
-        if len(name) > MAX_FOLDER_NAME_LENGTH:
-            log.warning("Truncating long folder name for account {}; "
-                        "original name was '{}'" .format(account.id, name))
-            name = name[:MAX_FOLDER_NAME_LENGTH]
-        q = q.filter(cls.name == name)
+        q = session.query(cls).filter(cls.account_id == account.id)\
+            .filter(cls.name == name)
 
         role = role or ''
         try:

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -4,7 +4,7 @@ from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from inbox.models.base import MailSyncBase
-from inbox.models.category import Category, CategoryNameString
+from inbox.models.category import Category, CategoryNameString, sanitize_name
 from inbox.models.mixins import UpdatedAtMixin, DeletedAtMixin
 from inbox.models.constants import MAX_INDEXABLE_LENGTH
 from inbox.sqlalchemy_ext.util import bakery
@@ -51,7 +51,7 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     @validates('name')
     def validate_name(self, key, name):
-        sanitized_name = Category.sanitize_name(name)
+        sanitized_name = sanitize_name(name)
         if sanitized_name != name:
             log.warning("Truncating folder name for account",
                         account_id=self.account_id, name=name)

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -4,7 +4,7 @@ from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from inbox.models.base import MailSyncBase
-from inbox.models.category import Category, CategoryNameType
+from inbox.models.category import Category, CategoryNameString
 from inbox.models.mixins import UpdatedAtMixin, DeletedAtMixin
 from inbox.models.constants import MAX_INDEXABLE_LENGTH
 from inbox.sqlalchemy_ext.util import bakery
@@ -36,8 +36,7 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
     # NOTE: this doesn't hold for EAS, which is case insensitive for non-Inbox
     # folders as per
     # https://msdn.microsoft.com/en-us/library/ee624913(v=exchg.80).aspx
-    name = Column(CategoryNameType(MAX_INDEXABLE_LENGTH,
-                  collation='utf8mb4_bin'), nullable=False)
+    name = Column(CategoryNameString(), nullable=False)
     canonical_name = Column(String(MAX_INDEXABLE_LENGTH), nullable=False,
                             default='')
 

--- a/inbox/models/label.py
+++ b/inbox/models/label.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import relationship, backref, validates
 from sqlalchemy.schema import UniqueConstraint
 
 from inbox.models.base import MailSyncBase
-from inbox.models.category import Category, CategoryNameType
+from inbox.models.category import Category, CategoryNameString
 from inbox.models.mixins import UpdatedAtMixin, DeletedAtMixin
 from inbox.models.constants import MAX_INDEXABLE_LENGTH
 from nylas.logging import get_logger
@@ -27,8 +27,7 @@ class Label(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
             passive_deletes=True),
         load_on_pending=True)
 
-    name = Column(CategoryNameType(MAX_INDEXABLE_LENGTH,
-                  collation='utf8mb4_bin'), nullable=False)
+    name = Column(CategoryNameString(), nullable=False)
     canonical_name = Column(String(MAX_INDEXABLE_LENGTH), nullable=False,
                             default='')
 

--- a/inbox/models/label.py
+++ b/inbox/models/label.py
@@ -5,7 +5,7 @@ from sqlalchemy.schema import UniqueConstraint
 from inbox.models.base import MailSyncBase
 from inbox.models.category import Category, CategoryNameType
 from inbox.models.mixins import UpdatedAtMixin, DeletedAtMixin
-from inbox.models.constants import MAX_LABEL_NAME_LENGTH
+from inbox.models.constants import MAX_INDEXABLE_LENGTH
 from nylas.logging import get_logger
 log = get_logger()
 
@@ -27,9 +27,9 @@ class Label(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
             passive_deletes=True),
         load_on_pending=True)
 
-    name = Column(CategoryNameType(MAX_LABEL_NAME_LENGTH,
+    name = Column(CategoryNameType(MAX_INDEXABLE_LENGTH,
                   collation='utf8mb4_bin'), nullable=False)
-    canonical_name = Column(String(MAX_LABEL_NAME_LENGTH), nullable=False,
+    canonical_name = Column(String(MAX_INDEXABLE_LENGTH), nullable=False,
                             default='')
 
     category_id = Column(ForeignKey(Category.id, ondelete='CASCADE'))

--- a/inbox/models/label.py
+++ b/inbox/models/label.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import relationship, backref, validates
 from sqlalchemy.schema import UniqueConstraint
 
 from inbox.models.base import MailSyncBase
-from inbox.models.category import Category, CategoryNameString
+from inbox.models.category import Category, CategoryNameString, sanitize_name
 from inbox.models.mixins import UpdatedAtMixin, DeletedAtMixin
 from inbox.models.constants import MAX_INDEXABLE_LENGTH
 from nylas.logging import get_logger
@@ -39,7 +39,7 @@ class Label(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     @validates('name')
     def validate_name(self, key, name):
-        sanitized_name = Category.sanitize_name(name)
+        sanitized_name = sanitize_name(name)
         if sanitized_name != name:
             log.warning("Truncating label name for account",
                         account_id=self.account_id, name=name)

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -13,6 +13,7 @@ from sqlalchemy.types import TypeDecorator, BINARY
 from sqlalchemy.interfaces import PoolListener
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext import baked
+from sqlalchemy.sql import operators
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.ext.declarative import DeclarativeMeta
 
@@ -65,6 +66,37 @@ class ABCMixin(object):
 
 # Column Types
 
+
+class StringWithTransform(TypeDecorator):
+    """
+    Column type that extends sqlalchemy.String so that any strings of
+    this type will be applied a user defined transform before saving them to the
+    database, and will make sure that any `==` queries executed against a Column
+    of this type match the values that we are actually storing in the database.
+
+    Note that this will only apply the transform at the database level, before
+    saving it, so column field in the model instance will /not/ have the
+    transform applied. If you want to make sure that all model instances have
+    the transform applied, you must manually apply it using a custom property
+    setter or a @validates decorator
+    """
+    impl = String
+
+    def __init__(self, string_transform, *args, **kwargs):
+        super(StringWithTransform, self).__init__(*args, **kwargs)
+        if string_transform is None:
+            raise ValueError('Must provide a string_transform')
+        if not hasattr(string_transform, '__call__'):
+            raise TypeError('`string_transform` must be callable')
+        self._string_transform = string_transform
+
+    def process_bind_param(self, value, dialect):
+        return self._string_transform(value)
+
+    class comparator_factory(String.Comparator):
+        def __eq__(self, other):
+            other = self.type._string_transform(other)
+            return self.operate(operators.eq, other)
 
 # http://docs.sqlalchemy.org/en/rel_0_9/core/types.html#marshal-json-strings
 class JSON(TypeDecorator):

--- a/tests/api/test_searching.py
+++ b/tests/api/test_searching.py
@@ -25,7 +25,7 @@ def test_gmail_thread(db, default_account):
 @fixture
 def imap_folder(db, generic_account):
     f = Folder.find_or_create(db.session, generic_account,
-                              'Boîte de réception', 'inbox')
+                              u'Boîte de réception', 'inbox')
     db.session.add(f)
     db.session.commit()
     return f

--- a/tests/general/test_category.py
+++ b/tests/general/test_category.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from inbox.models import Folder, Label
+from inbox.models.category import sanitize_name
+from inbox.models.constants import MAX_INDEXABLE_LENGTH
+from tests.util.base import (add_fake_folder, add_fake_label, generic_account,
+                             gmail_account, db)
+
+__all__ = ['db', 'generic_account', 'gmail_account']
+
+def test_category_sanitize_name():
+    assert sanitize_name(42) == u'42'
+    assert sanitize_name('42') == u'42'
+    assert sanitize_name(u'  Boîte de réception  ') ==\
+                                  u'  Boîte de réception'
+    long_name = 'N' * (MAX_INDEXABLE_LENGTH + 10)
+    assert sanitize_name(long_name) == 'N' * MAX_INDEXABLE_LENGTH
+
+    long_name = 'N' * (MAX_INDEXABLE_LENGTH - 2) + '  '
+    assert sanitize_name(long_name) == 'N' * (MAX_INDEXABLE_LENGTH - 2)
+
+def test_folder_sanitized(db, generic_account):
+    long_name = 'F' * (MAX_INDEXABLE_LENGTH + 10)
+    folder = add_fake_folder(db.session, generic_account, long_name)
+    assert len(folder.name) == MAX_INDEXABLE_LENGTH
+
+    # Test that we get back the correct model even when querying with a long
+    # name
+    found = db.session.query(Folder).filter(Folder.name == long_name).one()
+    assert len(found.name) == MAX_INDEXABLE_LENGTH
+    assert folder.id == found.id
+    assert found.name == folder.name
+
+def test_label_sanitized(db, gmail_account):
+    long_name = 'L' * (MAX_INDEXABLE_LENGTH + 10)
+    label = add_fake_label(db.session, gmail_account, long_name)
+    assert len(label.name) == MAX_INDEXABLE_LENGTH
+
+    # Test that we get back the correct model even when querying with a long
+    # name
+    found = db.session.query(Label).filter(Label.name == long_name).one()
+    assert len(found.name) == MAX_INDEXABLE_LENGTH
+    assert label.id == found.id
+    assert found.name == label.name

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -208,6 +208,10 @@ def add_fake_folder(db_session, default_account, display_name='All Mail',
     from inbox.models.folder import Folder
     return Folder.find_or_create(db_session, default_account, display_name, name)
 
+def add_fake_label(db_session, default_account, display_name='My Label',
+                    name=None):
+    from inbox.models.label import Label
+    return Label.find_or_create(db_session, default_account, display_name, name)
 
 def add_generic_imap_account(db_session, email_address='test@nylas.com'):
     import platform


### PR DESCRIPTION
- Cleans up Folder/Label/Category name sanitization code which was mostly duplicated
- Added a custom string type for Category names to make sure we always store properly sanitized strings, and extends `__eq__` comparison to compare against the truncated string, which is what we actually store in the database, even if the user queries using a longer (original) name. Going forward, any queries by name will now compare against the correct string.
- This only affects querying-- we still use the full folder name to be able to select the folder correctly in IMAP inside the sync engine
- Improves logging -- don't interpolate strings in the logs!

- This addresses most occurrences of https://sentry.nylas.com/sentry/sync-prod/group/8243/events/