### PR TITLE
Add support for non-optimistic updates (+ API versioning)

### DIFF
--- a/bin/dump-databases
+++ b/bin/dump-databases
@@ -1,0 +1,2 @@
+#!/bin/sh
+mysqldump --databases inbox inbox_1 inbox_2 inbox_3 -uroot -proot

--- a/bin/load-dump
+++ b/bin/load-dump
@@ -1,0 +1,2 @@
+#!/bin/sh
+mysql -uroot -proot < $1

--- a/inbox/actions/backends/generic.py
+++ b/inbox/actions/backends/generic.py
@@ -11,6 +11,7 @@ from inbox.models.session import session_scope
 from imaplib import IMAP4
 from inbox.sendmail.base import generate_attachments
 from inbox.sendmail.message import create_email
+from inbox.util.misc import imap_folder_path
 
 log = get_logger()
 

--- a/inbox/actions/backends/gmail.py
+++ b/inbox/actions/backends/gmail.py
@@ -40,13 +40,9 @@ def remote_create_label(crispin_client, account_id, category_id):
     crispin_client.conn.create_folder(display_name)
 
 
-def remote_update_label(crispin_client, account_id, category_id, old_name):
-    with session_scope(account_id) as db_session:
-        category = db_session.query(Category).get(category_id)
-        if category is None:
-            return
-        display_name = category.display_name
-    crispin_client.conn.rename_folder(old_name, display_name)
+def remote_update_label(crispin_client, account_id, category_id, old_name,
+                        new_name):
+    crispin_client.conn.rename_folder(old_name, new_name)
 
 
 def remote_delete_label(crispin_client, account_id, category_id):
@@ -63,6 +59,9 @@ def remote_delete_label(crispin_client, account_id, category_id):
         # no-op.
         pass
 
+    # TODO @karim --- the main sync loop has a hard time detecting
+    # Gmail renames because of a Gmail issue (see https://github.com/nylas/sync-engine/blob/c99656df3c048faf7951e54d74cb5ef9d7dc3c97/inbox/mailsync/gc.py#L146 for more details).
+    # Fix the problem and then remove the following shortcut.
     with session_scope(account_id) as db_session:
         category = db_session.query(Category).get(category_id)
         db_session.delete(category)

--- a/inbox/actions/base.py
+++ b/inbox/actions/base.py
@@ -71,26 +71,30 @@ def create_folder(crispin_client, account_id, category_id):
     remote_create_folder(crispin_client, account_id, category_id)
 
 
-def create_label(crispin_client, account_id, category_id):
-    remote_create_label(crispin_client, account_id, category_id)
-
-
-def delete_label(crispin_client, account_id, category_id):
-    remote_delete_label(crispin_client, account_id, category_id)
-
-
 def update_folder(crispin_client, account_id, category_id, args):
     old_name = args['old_name']
-    remote_update_folder(crispin_client, account_id, category_id, old_name)
+    new_name = args['new_name']
+    remote_update_folder(crispin_client, account_id, category_id,
+                         old_name, new_name)
 
 
 def delete_folder(crispin_client, account_id, category_id):
     remote_delete_folder(crispin_client, account_id, category_id)
 
 
+def create_label(crispin_client, account_id, category_id):
+    remote_create_label(crispin_client, account_id, category_id)
+
+
 def update_label(crispin_client, account_id, category_id, args):
     old_name = args['old_name']
-    remote_update_label(crispin_client, account_id, category_id, old_name)
+    new_name = args['new_name']
+    remote_update_label(crispin_client, account_id, category_id,
+                        old_name, new_name)
+
+
+def delete_label(crispin_client, account_id, category_id):
+    remote_delete_label(crispin_client, account_id, category_id)
 
 
 def save_draft(crispin_client, account_id, message_id, args):

--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -53,8 +53,7 @@ from inbox.search.base import get_search_client, SearchBackendException
 from inbox.transactions import delta_sync
 from inbox.api.err import (err, APIException, NotFoundError, InputError,
                            AccountDoesNotExistError, log_exception)
-from inbox.events.ical import (generate_icalendar_invite, send_invite,
-                               generate_rsvp, send_rsvp)
+from inbox.events.ical import generate_rsvp, send_rsvp
 from inbox.events.util import removed_participants
 from inbox.util.blockstore import get_from_blockstore
 from inbox.util.misc import imap_folder_path

--- a/inbox/api/update.py
+++ b/inbox/api/update.py
@@ -9,11 +9,11 @@ from inbox.api.err import InputError
 # STOPSHIP(emfree): better naming/structure for this module
 
 
-def update_message(message, request_data, db_session):
+def update_message(message, request_data, db_session, optimistic):
     accept_labels = message.namespace.account.provider == 'gmail'
     # Update flags (message.{is_read, is_starred})
     unread, starred = parse_flags(request_data)
-    update_message_flags(message, db_session, unread, starred)
+    update_message_flags(message, db_session, optimistic, unread, starred)
     # Update folders/ labels (message.categories)
     if accept_labels:
         labels = parse_labels(request_data, db_session, message.namespace_id)
@@ -21,14 +21,15 @@ def update_message(message, request_data, db_session):
             added_labels = labels - set(message.categories)
             removed_labels = set(message.categories) - labels
             update_message_labels(message, db_session, added_labels,
-                                  removed_labels)
+                                  removed_labels, optimistic)
     else:
         folder = parse_folder(request_data, db_session, message.namespace_id)
         if folder is not None:
-            update_message_folder(message, db_session, folder)
+            update_message_folder(message, db_session, folder,
+                                  optimistic)
 
 
-def update_thread(thread, request_data, db_session):
+def update_thread(thread, request_data, db_session, optimistic):
     accept_labels = thread.namespace.account.provider == 'gmail'
 
     unread, starred, = parse_flags(request_data)
@@ -48,18 +49,20 @@ def update_thread(thread, request_data, db_session):
             for message in thread.messages:
                 if not message.is_draft:
                     update_message_labels(message, db_session, new_labels,
-                                          removed_labels)
+                                          removed_labels, optimistic)
 
     elif folder is not None:
         for message in thread.messages:
             # Exclude drafts and sent messages from thread-level moves.
             if (not message.is_draft and not message.is_sent and
                     'sent' not in {c.name for c in message.categories}):
-                update_message_folder(message, db_session, folder)
+                update_message_folder(message, db_session, folder,
+                                      optimistic)
 
     for message in thread.messages:
         if not message.is_draft:
-            update_message_flags(message, db_session, unread, starred)
+            update_message_flags(message, db_session, optimistic, unread,
+                                 starred)
 
 ## FLAG UPDATES ##
 
@@ -75,14 +78,19 @@ def parse_flags(request_data):
     return unread, starred
 
 
-def update_message_flags(message, db_session, unread=None, starred=None):
+def update_message_flags(message, db_session, optimistic, unread=None,
+                         starred=None):
     if unread is not None and unread == message.is_read:
-        message.is_read = not unread
+        if optimistic:
+            message.is_read = not unread
+
         schedule_action('mark_unread', message, message.namespace_id,
                         db_session, unread=unread)
 
     if starred is not None and starred != message.is_starred:
-        message.is_starred = starred
+        if optimistic:
+            message.is_starred = starred
+
         schedule_action('mark_starred', message, message.namespace_id,
                         db_session, starred=starred)
 
@@ -110,11 +118,13 @@ def parse_folder(request_data, db_session, namespace_id):
                          format(folder_public_id))
 
 
-def update_message_folder(message, db_session, category):
+def update_message_folder(message, db_session, category, optimistic):
     # STOPSHIP(emfree): what about sent/inbox duality?
     if category not in message.categories:
-        message.categories = [category]
-        message.categories_changes = True
+        if optimistic:
+            message.categories = [category]
+            message.categories_changes = True
+
         schedule_action('move', message, message.namespace_id, db_session,
                         destination=category.display_name)
 
@@ -125,8 +135,10 @@ def parse_labels(request_data, db_session, namespace_id):
     # TODO deprecate being able to post "labels" and not "label_ids"
     if 'label_ids' not in request_data and 'labels' not in request_data:
         return
+
     label_public_ids = request_data.pop('label_ids', []) or \
         request_data.pop('labels', [])
+
     if not label_public_ids:
         # One of 'label_ids'/ 'labels' was present AND set to [].
         # Not allowed.
@@ -135,6 +147,7 @@ def parse_labels(request_data, db_session, namespace_id):
     # TODO(emfree): Use a real JSON schema validator for this sort of thing.
     if not isinstance(label_public_ids, list):
         raise InputError('"labels" must be a list')
+
     for id_ in label_public_ids:
         valid_public_id(id_)
 
@@ -151,7 +164,7 @@ def parse_labels(request_data, db_session, namespace_id):
 
 
 def update_message_labels(message, db_session, added_categories,
-                          removed_categories):
+                          removed_categories, optimistic):
     special_label_map = {
         'inbox': '\\Inbox',
         'important': '\\Important',
@@ -182,22 +195,27 @@ def update_message_labels(message, db_session, added_categories,
         else:
             removed_labels.append(category.display_name)
 
-    # Optimistically update message state,
-    # in a manner that is consistent with Gmail.
-    for cat in added_categories:
-        message.categories.add(cat)
-    for cat in removed_categories:
-        # Removing '\\All'/ \\Trash'/ '\\Spam' does not do anything on Gmail
-        # i.e. does not move the message to a different folder, so don't
-        # discard the corresponding category yet.
-        # If one of these has been *added* too, apply_gmail_label_rules()
-        # will do the right thing to ensure mutual exclusion.
-        if cat.name not in ('all', 'trash', 'spam'):
-            message.categories.discard(cat)
-    apply_gmail_label_rules(db_session, message, added_categories, removed_categories)
+    if optimistic:
+        # Optimistically update message state,
+        # in a manner consistent with Gmail.
+        for cat in added_categories:
+            message.categories.add(cat)
+
+        for cat in removed_categories:
+            # Removing '\\All'/ \\Trash'/ '\\Spam' does not do anything on Gmail
+            # i.e. does not move the message to a different folder, so don't
+            # discard the corresponding category yet.
+            # If one of these has been *added* too, apply_gmail_label_rules()
+            # will do the right thing to ensure mutual exclusion.
+            if cat.name not in ('all', 'trash', 'spam'):
+                message.categories.discard(cat)
+
+        apply_gmail_label_rules(db_session, message, added_categories, removed_categories)
+
+        if removed_labels or added_labels:
+            message.categories_changes = True
 
     if removed_labels or added_labels:
-        message.categories_changes = True
         schedule_action('change_labels', message, message.namespace_id,
                         removed_labels=removed_labels,
                         added_labels=added_labels,

--- a/inbox/events/actions/base.py
+++ b/inbox/events/actions/base.py
@@ -39,6 +39,15 @@ def update_event(account_id, event_id, extra_args):
         account = db_session.query(Account).get(account_id)
         event = db_session.query(Event).get(event_id)
 
+        # Update our copy of the event before sending it.
+        if 'event_data' in extra_args:
+            data = extra_args['event_data']
+            for attr in Event.API_MODIFIABLE_FIELDS:
+                if attr in extra_args['event_data']:
+                    setattr(event, attr, data[attr])
+
+            event.sequence_number += 1
+
         # It doesn't make sense to update or delete an event we imported from
         # an iCalendar file.
         if event.calendar == account.emailed_events_calendar:
@@ -55,11 +64,15 @@ def update_event(account_id, event_id, extra_args):
             ical_file = generate_icalendar_invite(event).to_ical()
             send_invite(ical_file, event, account, invite_type='update')
 
+        db_session.commit()
+
 
 def delete_event(account_id, event_id, extra_args):
     with session_scope(account_id) as db_session:
         account = db_session.query(Account).get(account_id)
         event = db_session.query(Event).get(event_id)
+        notify_participants = extra_args.get('notify_participants', False)
+
         remote_delete_event = module_registry[account.provider]. \
             remote_delete_event
         event_uid = extra_args.pop('event_uid', None)
@@ -73,3 +86,14 @@ def delete_event(account_id, event_id, extra_args):
 
         remote_delete_event(account, event_uid, calendar_name, calendar_uid,
                             db_session, extra_args)
+
+        # Finally, update the event.
+        event.sequence_number += 1
+        event.status = 'cancelled'
+        db_session.commit()
+
+        if notify_participants and account.provider != 'gmail':
+            ical_file = generate_icalendar_invite(event,
+                                                  invite_type='cancel').to_ical()
+
+            send_invite(ical_file, event, account, invite_type='cancel')

--- a/inbox/util/itert.py
+++ b/inbox/util/itert.py
@@ -27,5 +27,7 @@ def partition(pred, iterable):
     return list(itertools.ifilterfalse(pred, t1)), filter(pred, t2)
 
 
-def flatten(list_of_lists):
-    return [item for sublist in list_of_lists for item in sublist]
+def flatten(iterable):
+    # Flatten a list of lists.
+    # http://stackoverflow.com/a/953097
+    return list(itertools.chain(*iterable))

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -37,8 +37,9 @@ class TestAPIClient(object):
         headers.update(self.auth_header)
         return self.client.get(path, headers=headers)
 
-    def get_data(self, path):
-        return json.loads(self.client.get(path, headers=self.auth_header).data)
+    def get_data(self, path, headers={}):
+        headers.update(self.auth_header)
+        return json.loads(self.client.get(path, headers=headers).data)
 
     def post_data(self, path, data, headers={}):
         headers.update(self.auth_header)
@@ -48,10 +49,12 @@ class TestAPIClient(object):
         headers.update(self.auth_header)
         return self.client.post(path, data=data, headers=headers)
 
-    def put_data(self, path, data):
-        return self.client.put(path, headers=self.auth_header,
+    def put_data(self, path, data, headers={}):
+        headers.update(self.auth_header)
+        return self.client.put(path, headers=headers,
                                data=json.dumps(data))
 
-    def delete(self, path, data=None):
-        return self.client.delete(path, headers=self.auth_header,
+    def delete(self, path, data=None, headers={}):
+        headers.update(self.auth_header)
+        return self.client.delete(path, headers=headers,
                                   data=json.dumps(data))

--- a/tests/api/test_threads.py
+++ b/tests/api/test_threads.py
@@ -1,5 +1,7 @@
 import json
 import datetime
+import pytest
+from inbox.api.ns_api import API_VERSIONS
 from tests.util.base import (add_fake_message, default_account,
                              add_fake_thread, db)
 from tests.api.base import api_client
@@ -71,3 +73,77 @@ def test_thread_sent_recent_date(db, api_client, default_account):
     for thread in threads:  # should only be one
         assert datetime.datetime.fromtimestamp(
             thread['last_message_sent_timestamp']) == date2
+
+
+def test_thread_count(db, api_client, default_account):
+    date1 = datetime.datetime(2015, 1, 1, 0, 0, 0)
+    date2 = datetime.datetime(2012, 1, 1, 0, 0, 0)
+    date3 = datetime.datetime(2010, 1, 1, 0, 0, 0)
+    date4 = datetime.datetime(2009, 1, 1, 0, 0, 0)
+    date5 = datetime.datetime(2008, 1, 1, 0, 0, 0)
+
+    thread1 = add_fake_thread(db.session, default_account.namespace.id)
+    thread2 = add_fake_thread(db.session, default_account.namespace.id)
+
+    test_subject = "test_thread_view_count_with_category"
+
+    for thread in [thread1, thread2]:
+        add_fake_message(db.session, default_account.namespace.id, thread,
+                         subject=test_subject, received_date=date1)
+        add_fake_message(db.session, default_account.namespace.id, thread,
+                         subject=test_subject, received_date=date2,
+                         add_sent_category=True)
+        add_fake_message(db.session, default_account.namespace.id, thread,
+                         subject=test_subject, received_date=date3)
+        add_fake_message(db.session, default_account.namespace.id, thread,
+                         subject=test_subject, received_date=date4,
+                         add_sent_category=True)
+        add_fake_message(db.session, default_account.namespace.id, thread,
+                         subject=test_subject, received_date=date5)
+
+    resp = api_client.get_raw('/threads/?view=count&in=sent')
+    assert resp.status_code == 200
+    threads = json.loads(resp.data)
+    assert threads['count'] == 2
+
+
+@pytest.mark.parametrize("api_version", API_VERSIONS)
+def test_thread_label_updates(db, api_client, default_account, api_version,
+                              custom_label):
+    """Check that you can update a message (optimistically or not),
+    and that the update is queued in the ActionLog."""
+
+    headers = dict()
+    headers['Api-Version'] = api_version
+
+    # Gmail threads, messages have a 'labels' field
+    gmail_thread = add_fake_thread(db.session, default_account.namespace.id)
+    gmail_message = add_fake_message(db.session,
+                                     default_account.namespace.id, gmail_thread)
+
+    resp_data = api_client.get_data(
+        '/threads/{}'.format(gmail_thread.public_id), headers=headers)
+
+    assert resp_data['labels'] == []
+
+    category = custom_label.category
+    update = dict(labels=[category.public_id])
+
+    resp = api_client.put_data(
+        '/threads/{}'.format(gmail_thread.public_id), update,
+                              headers=headers)
+
+    resp_data = json.loads(resp.data)
+
+    if api_version == API_VERSIONS[0]:
+        assert len(resp_data['labels']) == 1
+        assert resp_data['labels'][0]['id'] == category.public_id
+
+        # Also check that the label got added to the message.
+        resp_data = api_client.get_data(
+            '/messages/{}'.format(gmail_message.public_id), headers=headers)
+
+        assert len(resp_data['labels']) == 1
+        assert resp_data['labels'][0]['id'] == category.public_id
+    else:
+        assert resp_data['labels'] == []

--- a/tests/imap/test_actions.py
+++ b/tests/imap/test_actions.py
@@ -127,10 +127,12 @@ def test_folder_crud(db, default_account, mock_imapclient, obj_type):
         db.session.commit()
         if obj_type == 'folder':
             update_folder(crispin_client, default_account.id, cat.id,
-                          {'old_name': 'MyFolder'})
+                          {'old_name': 'MyFolder',
+                           'new_name': 'MyRenamedFolder'})
         else:
             update_label(crispin_client, default_account.id, cat.id,
-                         {'old_name': 'MyFolder'})
+                         {'old_name': 'MyFolder',
+                          'new_name': 'MyRenamedFolder'})
         mock_imapclient.rename_folder.assert_called_with('MyFolder',
                                                          'MyRenamedFolder')
 

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -505,6 +505,13 @@ def label(db, default_account):
                                 'Inbox', 'inbox')
 
 
+@fixture
+def custom_label(db, default_account):
+    from inbox.models import Label
+    return Label.find_or_create(db.session, default_account,
+                                'Kraftwerk', '')
+
+
 @yield_fixture
 def contact(db, default_account):
     yield add_fake_contact(db.session, default_account.namespace.id)


### PR DESCRIPTION
**Summary:**
This PR adds a new way to update API objects. Instead of updating API objects before pushing the changes to the backend server (aka optimistic updates), we now push the changes to the backend and wait for the sync engine to pick up the changes. This solves a lot of problems we've had previously with folder and labels, where our datastore and the remote server would get out of sync.

For example, in the case of a folder rename, PUTting changes to `/folders/my_id` will return the title of the original folder. The new name will be returned only once we've carried the folder rename operation. This is a breaking API change, which could be very confusing to our long-time API users.

To keep backward compatibility, I've introduced a very basic API versioning scheme, similar to what Github does with its API. API versions are dates. You can set the API version you'd like to use by setting the "X-Api-Version" header in your request. If you don't set this header, we'll default to the version set for your developer dashboard account (changes forthcoming).

This diff is pretty close to review but I need to take a final pass to make sure everything fits together.

**Test Plan:**
Make a final manual test pass using IMAP and Exchange accounts.

**Reviewers:**
spang, bengotow
