### PR TITLE
Make _trim_filename great again

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -32,6 +32,9 @@ from inbox.sqlalchemy_ext.util import MAX_MYSQL_INTEGER
 
 
 def _trim_filename(s, namespace_id, max_len=255):
+    if s is None:
+        return s
+
     # The filename may be up to 255 4-byte unicode characters. If the
     # filename is longer than that, truncate it appropriately.
 


### PR DESCRIPTION
Fixes the tests

Summary: It used to be None-safe, but it was recently changed which broke some tests.

Test Plan: Run the tests

Reviewers: spang bengotow
