### PR TITLE
Return correct number of Threads with in_ and limit filters

### DIFF
--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -150,8 +150,6 @@ def threads(namespace_id, subject, from_addr, to_addr, cc_addr, bcc_addr,
     if view == 'ids':
         return [x[0] for x in query.all()]
 
-
-
     return query.all()
 
 

--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -35,7 +35,7 @@ def _threads_filters(namespace_id, thread_public_id, started_before,
 
 
 def _threads_subqueries(namespace_id, from_addr, to_addr, cc_addr, bcc_addr,
-                        any_email, filename, unread, starred, db_session):
+                        any_email, filename, unread, starred, db_session, in_):
     subqueries = []
     if from_addr is not None:
         subqueries.append(db_session.query(Message.thread_id).
@@ -93,10 +93,7 @@ def _threads_subqueries(namespace_id, from_addr, to_addr, cc_addr, bcc_addr,
         subqueries.append(db_session.query(Message.thread_id).
                           filter(Message.namespace_id == namespace_id,
                                  Message.is_starred == starred).subquery())
-    return subqueries
 
-
-def _threads_join_category(thread_query, namespace_id, in_):
     if in_ is not None:
         category_filters = [Category.name == in_, Category.display_name == in_]
         try:
@@ -104,12 +101,14 @@ def _threads_join_category(thread_query, namespace_id, in_):
             category_filters.append(Category.public_id == in_)
         except InputError:
             pass
-        return thread_query.join(Thread.messages). \
-            join(Message.messagecategories). \
-            join(MessageCategory.category). \
-            filter(Category.namespace_id == namespace_id,
-                   or_(*category_filters))
-    return thread_query
+
+        subqueries.append(db_session.query(Thread.id).join(Thread.messages).
+                          join(Message.messagecategories).
+                          join(MessageCategory.category).
+                          filter(Category.namespace_id == namespace_id,
+                                 or_(*category_filters)).subquery())
+
+    return subqueries
 
 
 def threads(namespace_id, subject, from_addr, to_addr, cc_addr, bcc_addr,
@@ -128,12 +127,16 @@ def threads(namespace_id, subject, from_addr, to_addr, cc_addr, bcc_addr,
                                started_after, last_message_before,
                                last_message_after, subject)
 
-    query = _threads_join_category(query, namespace_id, in_)
     query = query.filter(*filters)
+
     for subquery in _threads_subqueries(namespace_id, from_addr, to_addr,
                                         cc_addr, bcc_addr, any_email, filename,
-                                        unread, starred, db_session):
+                                        unread, starred, db_session, in_):
         query = query.filter(Thread.id.in_(subquery))
+
+    query = query.order_by(desc(Thread.recentdate)).limit(limit)
+    if offset:
+        query = query.offset(offset)
 
     if view == 'count':
         return {"count": query.one()[0]}
@@ -143,11 +146,6 @@ def threads(namespace_id, subject, from_addr, to_addr, cc_addr, bcc_addr,
     if view != 'ids':
         expand = (view == 'expanded')
         query = query.options(*Thread.api_loading_options(expand))
-
-    query = query.order_by(desc(Thread.recentdate)).limit(limit)
-
-    if offset:
-        query = query.offset(offset)
 
     if view == 'ids':
         return [x[0] for x in query.all()]

--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -134,10 +134,6 @@ def threads(namespace_id, subject, from_addr, to_addr, cc_addr, bcc_addr,
                                         unread, starred, db_session, in_):
         query = query.filter(Thread.id.in_(subquery))
 
-    query = query.order_by(desc(Thread.recentdate)).limit(limit)
-    if offset:
-        query = query.offset(offset)
-
     if view == 'count':
         return {"count": query.one()[0]}
 
@@ -147,8 +143,14 @@ def threads(namespace_id, subject, from_addr, to_addr, cc_addr, bcc_addr,
         expand = (view == 'expanded')
         query = query.options(*Thread.api_loading_options(expand))
 
+    query = query.order_by(desc(Thread.recentdate)).limit(limit)
+    if offset:
+        query = query.offset(offset)
+
     if view == 'ids':
         return [x[0] for x in query.all()]
+
+
 
     return query.all()
 

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -257,20 +257,25 @@ def test_distinct_results(api_client, db, default_namespace):
     first_thread = add_fake_thread(db.session, default_namespace.id)
     add_fake_message(db.session, default_namespace.id, first_thread,
                      from_addr=[('', 'hello@example.com')],
-                     received_date=datetime.datetime.utcnow())
+                     received_date=datetime.datetime.utcnow(),
+                     add_sent_category=True)
     add_fake_message(db.session, default_namespace.id, first_thread,
                      from_addr=[('', 'hello@example.com')],
-                     received_date=datetime.datetime.utcnow())
+                     received_date=datetime.datetime.utcnow(),
+                     add_sent_category=True)
 
     # Now create another thread with the same participants
     older_date = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
     second_thread = add_fake_thread(db.session, default_namespace.id)
     add_fake_message(db.session, default_namespace.id, second_thread,
                      from_addr=[('', 'hello@example.com')],
-                     received_date=older_date)
+                     received_date=older_date,
+                     add_sent_category=True)
     add_fake_message(db.session, default_namespace.id, second_thread,
                      from_addr=[('', 'hello@example.com')],
-                     received_date=older_date)
+                     received_date=older_date,
+                     add_sent_category=True)
+
     second_thread.recentdate = older_date
     db.session.commit()
 
@@ -290,6 +295,15 @@ def test_distinct_results(api_client, db, default_namespace):
 
     filtered_results = api_client.get_data('/threads?from=hello@example.com'
                                            '&limit=2&offset=1')
+    assert len(filtered_results) == 1
+
+    # Ensure that it works when using the _in filter
+    filtered_results = api_client.get_data('/threads?in=sent'
+                                           '&limit=2&offset=0')
+    assert len(filtered_results) == 2
+
+    filtered_results = api_client.get_data('/threads?in=sent'
+                                           '&limit=1&offset=0')
     assert len(filtered_results) == 1
 
 


### PR DESCRIPTION
Fixes nylas/redwood#12

Summary: We were returning the wrong number of threads when `in_` and `limit` filters were present since it was applied on a join with Messages rather than a subquery. By using a subquery for the `in_` filter, the limit will be applied on just the `Thread.id` rather than the results returned from a join with Message.

Test Plan: Added regression test

