### PR TITLE
Use FLAGS.SILENT instead of FLAGS, skip parsing unused response

### DIFF
--- a/inbox/actions/backends/generic.py
+++ b/inbox/actions/backends/generic.py
@@ -66,9 +66,9 @@ def _set_flag(crispin_client, account_id, message_id, flag_name,
     for folder_name, uids in uids_for_message.items():
         crispin_client.select_folder_if_necessary(folder_name, uidvalidity_cb)
         if is_add:
-            crispin_client.conn.add_flags(uids, [flag_name])
+            crispin_client.conn.add_flags(uids, [flag_name], silent=True)
         else:
-            crispin_client.conn.remove_flags(uids, [flag_name])
+            crispin_client.conn.remove_flags(uids, [flag_name], silent=True)
 
 
 def set_remote_starred(crispin_client, account, message_id, starred):

--- a/inbox/actions/backends/gmail.py
+++ b/inbox/actions/backends/gmail.py
@@ -25,10 +25,10 @@ def remote_change_labels(crispin_client, account_id, message_id,
         crispin_client.select_folder_if_necessary(folder_name, uidvalidity_cb)
         if len(added_labels) > 0:
             crispin_client.conn.add_gmail_labels(
-                uids, _encode_labels(added_labels))
+                uids, _encode_labels(added_labels), silent=True)
         if len(removed_labels) > 0:
             crispin_client.conn.remove_gmail_labels(
-                uids, _encode_labels(removed_labels))
+                uids, _encode_labels(removed_labels), silent=True)
 
 
 def remote_create_label(crispin_client, account_id, category_id):

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -709,21 +709,21 @@ class CrispinClient(object):
 
     def delete_uids(self, uids):
         uids = [str(u) for u in uids]
-        self.conn.delete_messages(uids)
+        self.conn.delete_messages(uids, silent=True)
         self.conn.expunge()
 
     def set_starred(self, uids, starred):
         if starred:
-            self.conn.add_flags(uids, ['\\Flagged'])
+            self.conn.add_flags(uids, ['\\Flagged'], silent=True)
         else:
-            self.conn.remove_flags(uids, ['\\Flagged'])
+            self.conn.remove_flags(uids, ['\\Flagged'], silent=True)
 
     def set_unread(self, uids, unread):
         uids = [str(u) for u in uids]
         if unread:
-            self.conn.remove_flags(uids, ['\\Seen'])
+            self.conn.remove_flags(uids, ['\\Seen'], silent=True)
         else:
-            self.conn.add_flags(uids, ['\\Seen'])
+            self.conn.add_flags(uids, ['\\Seen'], silent=True)
 
     def save_draft(self, message, date=None):
         assert self.selected_folder_name in self.folder_names()['drafts'], \
@@ -836,7 +836,7 @@ class CrispinClient(object):
                       message_id_header=message_id_header,
                       uids=matching_uids)
             return False
-        self.conn.delete_messages(matching_uids)
+        self.conn.delete_messages(matching_uids, silent=True)
         self.conn.expunge()
         return True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,5 +59,5 @@ psutil==3.3.0
 pyopenssl>=0.15.1
 gevent_openssl==1.2
 backports.ssl==0.0.9
-imapclient==1.0.1
+git+https://github.com/nylas/imapclient.git@2e420c44b77ee07bf2b9b9699302db74fd83af0c#egg=imapclient
 tldextract==1.7.5

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -217,7 +217,7 @@ class MockIMAPClient(object):
                                         folder_data.values())
         return resp
 
-    def delete_messages(self, uids):
+    def delete_messages(self, uids, silent=False):
         for u in uids:
             del self._data[self.selected_folder][u]
 

--- a/tests/imap/test_actions.py
+++ b/tests/imap/test_actions.py
@@ -78,19 +78,19 @@ def test_change_flags(db, default_account, message, folder, mock_imapclient):
     with writable_connection_pool(default_account.id).get() as crispin_client:
         mark_unread(crispin_client, default_account.id, message.id,
                     {'unread': False})
-        mock_imapclient.add_flags.assert_called_with([22], ['\\Seen'])
+        mock_imapclient.add_flags.assert_called_with([22], ['\\Seen'], silent=True)
 
         mark_unread(crispin_client, default_account.id, message.id,
                     {'unread': True})
-        mock_imapclient.remove_flags.assert_called_with([22], ['\\Seen'])
+        mock_imapclient.remove_flags.assert_called_with([22], ['\\Seen'], silent=True)
 
         mark_starred(crispin_client, default_account.id, message.id,
                      {'starred': True})
-        mock_imapclient.add_flags.assert_called_with([22], ['\\Flagged'])
+        mock_imapclient.add_flags.assert_called_with([22], ['\\Flagged'], silent=True)
 
         mark_starred(crispin_client, default_account.id, message.id,
                      {'starred': False})
-        mock_imapclient.remove_flags.assert_called_with([22], ['\\Flagged'])
+        mock_imapclient.remove_flags.assert_called_with([22], ['\\Flagged'], silent=True)
 
 
 def test_change_labels(db, default_account, message, folder, mock_imapclient):
@@ -104,8 +104,9 @@ def test_change_labels(db, default_account, message, folder, mock_imapclient):
                       {'removed_labels': ['\\Inbox'],
                        'added_labels': [u'motörhead', u'μετάνοια']})
         mock_imapclient.add_gmail_labels.assert_called_with(
-            [22], ['mot&APY-rhead', '&A7wDtQPEA6wDvQO,A7kDsQ-'])
-        mock_imapclient.remove_gmail_labels.assert_called_with([22], ['\\Inbox'])
+            [22], ['mot&APY-rhead', '&A7wDtQPEA6wDvQO,A7kDsQ-'], silent=True)
+        mock_imapclient.remove_gmail_labels.assert_called_with([22], ['\\Inbox'],
+                                                               silent=True)
 
 
 @pytest.mark.parametrize('obj_type', ['folder', 'label'])


### PR DESCRIPTION
This PR began as an investigation into parsing errors impacting 6k accounts in Sentry: https://sentry.nylas.com/sentry/sync-prod/group/7660/.

It's unclear exactly how data about the wrong UIDs appears in the response, but I realized about half-way through investigation that we are not actually using the response from these IMAP `STORE` commands at all, and it would be more efficient to call the `.SILENT` versions of them. I added support for the silent variants to imapclient in https://github.com/nylas/imapclient/commit/2e420c44b77ee07bf2b9b9699302db74fd83af0c. When making a silent command (`STORE +FLAGS.SILENT (\Seen)`), the server still returns an OK when it's done with the command, but does not perform a FETCH for the new flag values.

Based on some limited testing (marking a single message read / unread 10x with SILENT and 10x without SILENT, on separate connections each time), it seems like it's only marginally faster (about 15%), but it seems like a good solution to the parsing issue since we don't look at the response.

It's also worth mentioning that the NodeJS IMAP library always uses SILENT: https://github.com/mscdex/node-imap/blob/3051724f85ac2efbf887d112c91f669919186897/lib/Connection.js#L657