### PR TITLE
Update folder roles if they've been changed

### DIFF
--- a/inbox/folder_edge_cases.py
+++ b/inbox/folder_edge_cases.py
@@ -16,10 +16,11 @@ localized_folder_names = {
               '\xd0\xa1\xd0\xbc\xd1\x96\xd1\x82\xd1\x82\xd1\x8f',
               'Papierkorb/Trash', 'Gel\xc3\xb6schte Elemente',
               'Deleted Messages', '[Gmail]/Trash', 'INBOX/Trash', 'Trash',
-              'mail/TRASH'},
+              'mail/TRASH', 'INBOX.Trash'},
     'spam': {'Roskaposti', 'INBOX.spam', 'INBOX.Spam', 'Skr\xc3\xa4ppost',
              'Spamverdacht', 'spam', 'Spam', '[Gmail]/Spam', '[Imap]/Spam',
-             '\xe5\x9e\x83\xe5\x9c\xbe\xe9\x82\xae\xe4\xbb\xb6'},
+             '\xe5\x9e\x83\xe5\x9c\xbe\xe9\x82\xae\xe4\xbb\xb6', 'Junk',
+             'Junk Mail', 'Junk E-Mail'},
     'inbox': {u'INBOX'},
     'sent': {'Postausgang', 'INBOX.Gesendet', '[Gmail]/Sent Mail',
              '\xeb\xb3\xb4\xeb\x82\xbc\xed\x8e\xb8\xec\xa7\x80\xed\x95\xa8'

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -102,9 +102,12 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
 
         # Create new folders
         for raw_folder in raw_folders:
-            folder = Folder.find_or_create(db_session, account, raw_folder.display_name,
+            folder = Folder.find_or_create(db_session, account,
+                                           raw_folder.display_name,
                                            raw_folder.role)
-            Folder.update_role(folder, raw_folder.role)
+            if folder.canonical_name != raw_folder.role:
+                folder.canonical_name = raw_folder.role
+
         # Set the should_run bit for existing folders to True (it's True by
         # default for new ones.)
         for f in local_folders.values():

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -37,8 +37,18 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
     # folders as per
     # https://msdn.microsoft.com/en-us/library/ee624913(v=exchg.80).aspx
     name = Column(CategoryNameString(), nullable=False)
-    canonical_name = Column(String(MAX_INDEXABLE_LENGTH), nullable=False,
-                            default='')
+    _canonical_name = Column(String(MAX_INDEXABLE_LENGTH), nullable=False,
+                             default='', name="canonical_name")
+
+    @property
+    def canonical_name(self):
+        return self._canonical_name
+
+    @canonical_name.setter
+    def canonical_name(self, value):
+        value = value or ''
+        self._canonical_name = value
+        self.category.name = value
 
     category_id = Column(ForeignKey(Category.id, ondelete='CASCADE'))
     category = relationship(
@@ -77,16 +87,6 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
             raise
 
         return obj
-
-
-    @classmethod
-    def update_role(cls, obj, role=''):
-        role = role or ''  # Need this in case role is explicitly None
-        if obj.canonical_name != role:
-            obj.canonical_name = role
-        if obj.category.name != role:
-            obj.category.name = role
-
 
     @classmethod
     def get(cls, id_, session):

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -76,10 +76,17 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
                      .format(name, account.id))
             raise
 
-        if not obj.canonical_name:
-            obj.canonical_name = role
-
         return obj
+
+
+    @classmethod
+    def update_role(cls, obj, role=''):
+        role = role or ''  # Need this in case role is explicitly None
+        if obj.canonical_name != role:
+            obj.canonical_name = role
+        if obj.category.name != role:
+            obj.category.name = role
+
 
     @classmethod
     def get(cls, id_, session):


### PR DESCRIPTION
Fixes [N1/#1457](https://github.com/nylas/N1/issues/1457)

Summary:
We added a guessing mechanism to figure out which folders should be used for standard roles, but these guessed roles are only saved if it's the initial creation of a folder. Existing users when we implemented this have not seen any improvement in folder roles, even though the guessing mechanism seems to be returning the proper roles. This diff makes sure the roles get updated properly during sync.

Test Plan: Tested locally on a single IMAP account

Reviewers: khamidou
