### PR TITLE
Use SQLAlchemy's synonym for Folder canonical_name

### DIFF
--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, String, ForeignKey, DateTime, bindparam
-from sqlalchemy.orm import relationship, backref, validates
+from sqlalchemy.orm import relationship, backref, synonym, validates
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
@@ -50,6 +50,8 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
         self._canonical_name = value
         if self.category:
             self.category.name = value
+
+    canonical_name = synonym('_canonical_name', descriptor=canonical_name)
 
     category_id = Column(ForeignKey(Category.id, ondelete='CASCADE'))
     category = relationship(

--- a/tests/imap/test_save_folder_names.py
+++ b/tests/imap/test_save_folder_names.py
@@ -19,7 +19,7 @@ def test_imap_save_generic_folder_names(db, default_account):
     raw_folders = [RawFolder(*args) for args in folder_names_and_roles]
     monitor.save_folder_names(db.session, raw_folders)
     saved_folder_data = set(
-        db.session.query(Folder.name, Folder._canonical_name).filter(
+        db.session.query(Folder.name, Folder.canonical_name).filter(
             Folder.account_id == default_account.id).all())
     assert saved_folder_data == folder_names_and_roles
 
@@ -37,7 +37,7 @@ def test_handle_folder_deletions(db, default_account):
 
     monitor.save_folder_names(db.session, [RawFolder('INBOX', 'inbox')])
     saved_folder_data = set(
-        db.session.query(Folder.name, Folder._canonical_name).filter(
+        db.session.query(Folder.name, Folder.canonical_name).filter(
             Folder.account_id == default_account.id).all())
     assert saved_folder_data == {('INBOX', 'inbox')}
 
@@ -64,7 +64,7 @@ def test_imap_handle_folder_renames(db, default_account):
 
     monitor.save_folder_names(db.session, renamed_raw_folders)
     saved_folder_data = set(
-        db.session.query(Folder.name, Folder._canonical_name).filter(
+        db.session.query(Folder.name, Folder.canonical_name).filter(
             Folder.account_id == default_account.id).all())
     assert saved_folder_data == folders_renamed
 
@@ -100,7 +100,7 @@ def test_gmail_handle_folder_renames(db, default_account):
 
     monitor.save_folder_names(db.session, renamed_raw_folders)
     saved_folder_data = set(
-        db.session.query(Folder.name, Folder._canonical_name).filter(
+        db.session.query(Folder.name, Folder.canonical_name).filter(
             Folder.account_id == default_account.id).all())
     assert saved_folder_data == folders_renamed
 
@@ -131,7 +131,7 @@ def test_save_gmail_folder_names(db, default_account):
     monitor.save_folder_names(db.session, raw_folders)
 
     saved_folder_data = set(
-        db.session.query(Folder.name, Folder._canonical_name).filter(
+        db.session.query(Folder.name, Folder.canonical_name).filter(
             Folder.account_id == default_account.id)
     )
     assert saved_folder_data == {
@@ -171,7 +171,7 @@ def test_handle_trailing_whitespace(db, default_account):
     monitor = ImapSyncMonitor(default_account)
     monitor.save_folder_names(db.session, raw_folders)
     saved_folder_data = set(
-        db.session.query(Folder.name, Folder._canonical_name).filter(
+        db.session.query(Folder.name, Folder.canonical_name).filter(
             Folder.account_id == default_account.id)
     )
     assert saved_folder_data == {('Miscellania', ''), ('Inbox', 'inbox')}
@@ -209,7 +209,7 @@ def test_imap_remote_delete(db, default_account):
 
     monitor.save_folder_names(db.session, new_raw_folders)
     saved_folder_data = set(
-        db.session.query(Folder.name, Folder._canonical_name).filter(
+        db.session.query(Folder.name, Folder.canonical_name).filter(
             Folder.account_id == default_account.id).all())
     assert saved_folder_data == new_folders
 


### PR DESCRIPTION
Summary: This allows us to use the property getter/setter stuff while retaining the
ability to say things like "Folder.canonical_name" in SQLAlchemy queries.

Test Plan: Travis

Reviewers: spang hallamoore