### PR TITLE
Fix bin/inbox-auth to properly update account credentials instead of …

### DIFF
--- a/bin/inbox-auth
+++ b/bin/inbox-auth
@@ -53,8 +53,11 @@ def main(email_address, reauth, target, provider):
         auth_info['provider'] = provider
         auth_handler = handler_from_provider(provider)
         auth_info.update(auth_handler.interactive_auth(email_address))
-
-        account = auth_handler.create_account(email_address, auth_info)
+        
+        if reauth:
+          account = auth_handler.update_account(account, auth_info)
+        else:
+          account = auth_handler.create_account(email_address, auth_info)
 
         try:
             if auth_handler.verify_account(account):


### PR DESCRIPTION
Fixes #386 

Summary:
Adds a conditional to to auth_handler.update_account instead of auth_handler.create_account when '--reauth' parameter is passed to inbox-auth.

This enables less wasteful account credential updates in the open source sync engine by:
- Keeping the already downloaded data
- Not necessitating a complete re-adding of the sync engine instance to nylas

Patching this file is the only manual step involving the engine code for setting it up on lxd right now:
https://github.com/tbraeutigam/nmgmt
