### PR TITLE
update redis conf to fix a security issue

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -167,6 +167,9 @@ if ! ${prod}; then
         rm -f /tmp/6379.conf
         cd ../..
         rm -rf redis-${redis_version} redis-${redis_version}.tar.gz
+
+        # modify redis conf so that redis is only accessible localy
+        sed -i '/^#.*bind 127/s/^#//' /etc/redis/6379.conf
     fi
     color '34;1' 'redis-'${redis_version}' installed.'
 fi


### PR DESCRIPTION
Summary:
Bind the redis server only locally so that it is not reachable from elsewhere

Reviewers:
Please add the reviewer as an assignee to this PR on the right
@pfista 
