### PR TITLE
Add libssl-dev as an apt-get dependency

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -90,6 +90,7 @@ apt-get -y install git \
                    libxslt-dev \
                    lib32z1-dev \
                    libffi-dev \
+                   libssl-dev \
                    pkg-config \
                    python-lxml \
                    tmux \


### PR DESCRIPTION
Summary: libssl-dev is a required dependency of the python cryptography package which a required dependency of sync-engine.

Test Plan: run setup.sh on a blank machine and it should set up the sync engine successfully.