### PR TITLE
Clean Debian 8 installation support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,5 +64,6 @@ gevent_openssl==1.2
 backports.ssl==0.0.9
 git+https://github.com/mjs/imapclient.git@77047bafd9a82f3bb1faa5e909d776b7a2e1b432#egg=imapclient
 tldextract==1.7.5
+cffi>=1.6
 tox==2.3.1
 nylas==1.2.3

--- a/setup.sh
+++ b/setup.sh
@@ -90,6 +90,7 @@ apt-get -y install git \
                    libxslt-dev \
                    lib32z1-dev \
                    libffi-dev \
+                   libssl-dev \
                    pkg-config \
                    python-lxml \
                    tmux \
@@ -174,9 +175,9 @@ fi
 color '35;1' 'Ensuring setuptools and pip versions...'
 # If python-setuptools is actually the old 'distribute' fork of setuptools,
 # then the first 'pip install setuptools' will be a no-op.
-pip install 'pip==8.1.2' 'setuptools>=5.3'
+pip install 'pip==8.1.2' 'setuptools==18.2'
 hash pip        # /usr/bin/pip might now be /usr/local/bin/pip
-pip install 'pip==8.1.2' 'setuptools>=5.3'
+pip install 'pip==8.1.2' 'setuptools==18.2'
 
 # Doing pip upgrade setuptools leaves behind this problematic symlink
 rm -rf /usr/lib/python2.7/dist-packages/setuptools.egg-info


### PR DESCRIPTION
Fixes #268 #295 

Summary: used to install in clean Debian 8 container.

setuptools==18.2 is required:
 - 18.2 is minimum for smth I don't remember;
 - the current would fail to install imapclient.