### PR TITLE
fix ImportError

### DIFF
--- a/inbox/sendmail/message.py
+++ b/inbox/sendmail/message.py
@@ -20,7 +20,10 @@ from flanker import mime
 from flanker.addresslib import address
 from flanker.addresslib.quote import smart_quote
 from flanker.mime.message.headers.encoding import encode_string
-from flanker.addresslib.parser import MAX_ADDRESS_LENGTH
+try:
+    from flanker.addresslib.parser import MAX_ADDRESS_LENGTH
+except:
+    from flanker.addresslib.address import MAX_ADDRESS_LENGTH
 from html2text import html2text
 
 VERSION = pkg_resources.get_distribution('inbox-sync').version


### PR DESCRIPTION
BUG: ImportError: cannot import name MAX_ADDRESS_LENGTH

`MAX_ADDRESS_LENGTH` is in 'flanker.addresslib.address' at current version