### PR TITLE
Fixes bug where MAX_ADDRESS_LENGTH is missing in flanker library

### DIFF
--- a/inbox/sendmail/message.py
+++ b/inbox/sendmail/message.py
@@ -20,7 +20,10 @@ from flanker import mime
 from flanker.addresslib import address
 from flanker.addresslib.quote import smart_quote
 from flanker.mime.message.headers.encoding import encode_string
-from flanker.addresslib.parser import MAX_ADDRESS_LENGTH
+try:
+    from flanker.addresslib.parser import MAX_ADDRESS_LENGTH
+except:
+    MAX_ADDRESS_LENGTH = 25
 from html2text import html2text
 
 VERSION = pkg_resources.get_distribution('inbox-sync').version

--- a/inbox/sendmail/message.py
+++ b/inbox/sendmail/message.py
@@ -23,7 +23,7 @@ from flanker.mime.message.headers.encoding import encode_string
 try:
     from flanker.addresslib.parser import MAX_ADDRESS_LENGTH
 except:
-    MAX_ADDRESS_LENGTH = 25
+    MAX_ADDRESS_LENGTH = 1024
 from html2text import html2text
 
 VERSION = pkg_resources.get_distribution('inbox-sync').version


### PR DESCRIPTION
Fixes: Fixes bug where MAX_ADDRESS_LENGTH is missing in flanker library

Summary: It appears, that some of flanker library versions do not provide MAX_ADDRESS_LENGTH constant, this patch fixes this issue.

Test Plan:

Reviewers:
Please add the reviewer as an assignee to this PR on the right
