### PR TITLE
Add environment variable so binaries work; tweak install script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #   "--natdnsproxy1", "on",
   # ]
   config.vm.network "private_network", ip: "192.168.10.200"
+  config.vm.provision :shell, :inline => "echo 'export PYTHONPATH=/vagrant' > /etc/profile.d/vagrant.sh; chmod +x /etc/profile.d/vagrant.sh"
   config.vm.provision :shell, :inline => "apt-get update -q && cd /vagrant && ./setup.sh"
 
   # Share ports 5000 - 5009

--- a/setup.sh
+++ b/setup.sh
@@ -178,10 +178,10 @@ fi
 color '35;1' 'Ensuring setuptools and pip versions...'
 # Need up-to-date pyparsing or upgrading pip will break pip
 # https://github.com/pypa/packaging/issues/94
-pip install 'pyparsing==2.2.0'
+pip install -i https://pypi.python.org/simple 'pyparsing==2.2.0'
 # If python-setuptools is actually the old 'distribute' fork of setuptools,
 # then the first 'pip install setuptools' will be a no-op.
-pip install 'pip==9.0.1' 'setuptools==34.3.1'
+pip install -i https://pypi.python.org/simple 'pip==9.0.1' 'setuptools==34.3.1'
 hash pip        # /usr/bin/pip might now be /usr/local/bin/pip
 pip install 'pip==9.0.1' 'setuptools==34.3.1'
 
@@ -198,9 +198,12 @@ cd "$src_dir"
 color '35;1' 'Removing .pyc files...'   # they might be stale
 find . -name \*.pyc -delete
 
+color '35;1' 'Temporarily removing python-chardet (to resolve conflict, will re-install in next step)'
+apt-get remove -y python-chardet
+
 color '35;1' 'Installing dependencies from pip...'
-SODIUM_INSTALL=system pip install -r requirements.txt
-pip install -e .
+SODIUM_INSTALL=system pip install --disable-pip-version-check -r requirements.txt
+pip install  --disable-pip-version-check -e .
 
 color '35;1' 'Finished installing dependencies.'
 
@@ -274,7 +277,7 @@ if ! $prod; then
         fi
     fi
 
-    mysqld_safe &
+    # mysqld_safe & # I think 'upstart' does this for us?
     sleep 10
 
     env NYLAS_ENV=dev bin/create-db


### PR DESCRIPTION
I was trying to run this using the Vagrant method and I got some errors, so I thought I would just try and fix them.

First, the default version of `pip` that's already installed seems to try to install from the non-TLS version of the python repositories. 

Next, the Python `chardet` library version that the system wants conflicts with one that's already installed on Ubuntu. I just uninstalled the package so the new one can get put in instead.

I also disabled the `pip` version check, it just makes for confusing errors.

And the last change to the `setup.sh` script is - because of how `upstart` is hooked into the system, mysql seems to start on its own and the `mysqld_safe` binary doesn't need to be run directly.

Additionally, I modified the `Vagrantfile` to make the various binaries run as documented in the README. I adding a `profile.d` script to set the `PYTHONPATH` environment variable so those various binaries will execute correctly.

That last change seems weird; if that was something that was necessary I would expect it to already be there? If there's a better or different way to do that, I'm happy to rework my changes here to accommodate.