### PR TITLE
docs: archived notice + redirect to current Nylas API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,82 @@
 > [!CAUTION]
 > 🛑 **This repository is archived and no longer maintained.**
 >
-> The **Nylas Sync Engine** was an open-source email sync platform exposing a RESTful API on top of IMAP/SMTP; its capabilities now live on in the fully-hosted [Nylas API](https://developer.nylas.com/). Do not use it for new projects — see current Nylas resources below.
+> The Nylas Sync Engine was an open-source email sync platform (RESTful API over IMAP/SMTP). It is preserved here for historical reference. Its capabilities live on in the fully-hosted [Nylas API](https://developer.nylas.com/) — no self-hosting, no Vagrant, no infrastructure to run. [Sign up](https://dashboard-v3.nylas.com/register) or read the [docs](https://developer.nylas.com/).
 
-<div align="center">
-  <a href="https://www.nylas.com/">
-    <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
-  </a>
+---
 
-  <h1>Nylas Sync Engine</h1>
+# Nylas Sync Engine [![Build Status](https://travis-ci.org/nylas/sync-engine.svg?branch=master)](https://travis-ci.org/nylas/sync-engine)
 
-  <p><img src="https://img.shields.io/badge/Status-Archived-critical?style=for-the-badge" alt="Status: Archived" /></p>
-</div>
+The Nylas Sync Engine provides a RESTful API on top of a powerful email sync platform, making it easy to build apps on top of email. See the [full API documentation](https://www.nylas.com/docs/) for more details.
 
-<br />
+Need help? [Join our Slack channel ![Slack Invite Button](http://slack-invite.nylas.com/badge.svg)](http://slack-invite.nylas.com)
 
-## Use the hosted Nylas API instead
 
-Connect Gmail, Microsoft, IMAP, and 250+ providers in minutes — or give an AI agent its own mailbox.
+### Installation and Setup
 
-- 📖 [Developer documentation](https://developer.nylas.com/)
-- ⚡ [Getting started](https://developer.nylas.com/docs/v3/getting-started/)
-- 📚 [API reference](https://developer.nylas.com/docs/api/v3/)
-- 🚀 [Sign up for free](https://dashboard-v3.nylas.com/register)
-- 🤖 [Agent Accounts](https://developer.nylas.com/docs/v3/agent-accounts/)
+1. Install the latest versions of [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Install Vagrant](http://www.vagrantup.com/downloads.html).
 
-Covers [Agent Accounts](https://developer.nylas.com/docs/v3/agent-accounts/), [Email](https://developer.nylas.com/docs/v3/email/), [Calendar](https://developer.nylas.com/docs/v3/calendar/), [Contacts](https://developer.nylas.com/docs/v3/email/contacts/), [Scheduler](https://developer.nylas.com/docs/v3/scheduler/), and [Notetaker](https://developer.nylas.com/docs/v3/notetaker/).
+2. `git clone https://github.com/nylas/sync-engine.git`
+
+3. `cd sync-engine`
+
+4. `vagrant up`
+
+    Feel free to check out the `Vagrantfile` while this starts up. It creates a host-only network for the VM at `192.168.10.200`.
+
+5. `vagrant ssh`
+
+6. `cd /vagrant`
+
+7. `NYLAS_ENV=dev bin/inbox-start`
+
+And _voilà_! Auth an account via the commandline to start syncing:
+
+    bin/inbox-auth ben.bitdiddle1861@gmail.com
+
+The `inbox-auth` command will walk you through the process of obtaining an authorization token from Google or another service for syncing your mail. In the open-source version of the sync engine, your credentials are stored to the local MySQL database for simplicity. The open-source Nylas Sync Engine does not support Exchange, but the [hosted](https://www.nylas.com) version does.
+
+The sync engine will automatically begin syncing your account with the underlying provider. The `inbox-sync` command allows you to manually stop or restart the sync by running `inbox-sync stop [YOUR_ACCOUNT]@example.com` or `inbox-sync start [YOUR_ACCOUNT]@example.com`. Note that an initial sync can take quite a while depending on how much mail you have.
+
+### Nylas API Service
+
+The Nylas API service provides a REST API for interacting with your data. To start it in your development environment, run command below from the `/vagrant` folder within your VM:
+
+```bash
+$ bin/inbox-api
+```
+
+This will start the API Server on port 5555. At this point **You're now ready to make requests!** If you're using VirtualBox or VMWare fusion with Vagrant, port 5555 has already been forwarded to your host machine, so you can hit the API from your regular web browser.
+
+You can get a list of all connected accounts by requesting `http://localhost:5555/accounts`. This endpoint requires no authentication.
+
+For subsequent requests to retreive mail, contacts, and calendar data, your app should pass the `account_id` value from the previous step as the "username" parameter in HTTP Basic auth. For example:
+
+```
+curl --user 'ACCOUNT_ID_VALUE_HERE:' http://localhost:5555/threads
+```
+
+If you are using a web browser and would like to clear your cached HTTP Basic Auth values, simply visit http://localhost:5555/logout and click "Cancel".
+
+
+Now you can start writing your own application on top of the Nylas API! For more information about the internals of the Nylas Sync Engine, see the <a href="https://nylas.com/docs/">Nylas API Documentation</a>.
+
+
+## Production Support
+
+We provide a fully managed and supported version of the Nylas sync engine for production apps. Read more at https://nylas.com
+
+## Pull Requests
+
+We'd love your help making Nylas better! Please sign-up for a [developer account](https://nylas.com/register) for project updates and the latest news. Feel free to create issues or pull requests to start discussions.
+
+We require all authors sign our [Contributor License Agreement](https://www.nylas.com/cla.html) when submitting pull requests. (It's similar to other projects, like NodeJS or Meteor.)
+
+## Security
+
+For the sake of simplicity and setup speed, the development VM does not include any authentication or permission. For developing with sensitive data, we encourage developers to add their own protection, such as only running Nylas on a local machine or behind a controlled firewall.
+Note that passwords and OAuth tokens are stored unencrypted in the local MySQL data store on disk. This is intentional, for the same reason as above.
+
+## License
+
+This code is free software, licensed under the The GNU Affero General Public License (AGPL). See the `LICENSE` file for more details.

--- a/README.md
+++ b/README.md
@@ -1,75 +1,25 @@
-# Nylas Sync Engine [![Build Status](https://travis-ci.org/nylas/sync-engine.svg?branch=master)](https://travis-ci.org/nylas/sync-engine)
+<div align="center">
+  <a href="https://www.nylas.com/">
+    <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
+  </a>
 
-The Nylas Sync Engine provides a RESTful API on top of a powerful email sync platform, making it easy to build apps on top of email. See the [full API documentation](https://www.nylas.com/docs/) for more details.
+  <h1>Nylas Sync Engine</h1>
+</div>
 
-Need help? [Join our Slack channel ![Slack Invite Button](http://slack-invite.nylas.com/badge.svg)](http://slack-invite.nylas.com)
+<br />
 
+> ## ⚠️ This repository is archived and no longer maintained
+>
+> The **Nylas Sync Engine** was an open-source email sync platform that exposed a RESTful API on top of IMAP/SMTP. It is preserved here for historical reference and is no longer developed or supported. Its capabilities live on in the fully-hosted [Nylas API](https://developer.nylas.com/) — no self-hosting, no Vagrant, no infrastructure to run.
 
-### Installation and Setup
+## Use the hosted Nylas API instead
 
-1. Install the latest versions of [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Install Vagrant](http://www.vagrantup.com/downloads.html).
+Connect Gmail, Microsoft, IMAP, and 250+ providers in minutes — or give an AI agent its own mailbox.
 
-2. `git clone https://github.com/nylas/sync-engine.git`
+- 📖 [Developer documentation](https://developer.nylas.com/)
+- ⚡ [Getting started](https://developer.nylas.com/docs/v3/getting-started/)
+- 📚 [API reference](https://developer.nylas.com/docs/api/v3/)
+- 🚀 [Sign up for free](https://dashboard-v3.nylas.com/register)
+- 🤖 [Agent Accounts](https://developer.nylas.com/docs/v3/agent-accounts/)
 
-3. `cd sync-engine`
-
-4. `vagrant up`
-
-    Feel free to check out the `Vagrantfile` while this starts up. It creates a host-only network for the VM at `192.168.10.200`.
-
-5. `vagrant ssh`
-
-6. `cd /vagrant`
-
-7. `NYLAS_ENV=dev bin/inbox-start`
-
-And _voilà_! Auth an account via the commandline to start syncing:
-
-    bin/inbox-auth ben.bitdiddle1861@gmail.com
-
-The `inbox-auth` command will walk you through the process of obtaining an authorization token from Google or another service for syncing your mail. In the open-source version of the sync engine, your credentials are stored to the local MySQL database for simplicity. The open-source Nylas Sync Engine does not support Exchange, but the [hosted](https://www.nylas.com) version does.
-
-The sync engine will automatically begin syncing your account with the underlying provider. The `inbox-sync` command allows you to manually stop or restart the sync by running `inbox-sync stop [YOUR_ACCOUNT]@example.com` or `inbox-sync start [YOUR_ACCOUNT]@example.com`. Note that an initial sync can take quite a while depending on how much mail you have.
-
-### Nylas API Service
-
-The Nylas API service provides a REST API for interacting with your data. To start it in your development environment, run command below from the `/vagrant` folder within your VM:
-
-```bash
-$ bin/inbox-api
-```
-
-This will start the API Server on port 5555. At this point **You're now ready to make requests!** If you're using VirtualBox or VMWare fusion with Vagrant, port 5555 has already been forwarded to your host machine, so you can hit the API from your regular web browser.
-
-You can get a list of all connected accounts by requesting `http://localhost:5555/accounts`. This endpoint requires no authentication.
-
-For subsequent requests to retreive mail, contacts, and calendar data, your app should pass the `account_id` value from the previous step as the "username" parameter in HTTP Basic auth. For example:
-
-```
-curl --user 'ACCOUNT_ID_VALUE_HERE:' http://localhost:5555/threads
-```
-
-If you are using a web browser and would like to clear your cached HTTP Basic Auth values, simply visit http://localhost:5555/logout and click "Cancel".
-
-
-Now you can start writing your own application on top of the Nylas API! For more information about the internals of the Nylas Sync Engine, see the <a href="https://nylas.com/docs/">Nylas API Documentation</a>.
-
-
-## Production Support
-
-We provide a fully managed and supported version of the Nylas sync engine for production apps. Read more at https://nylas.com
-
-## Pull Requests
-
-We'd love your help making Nylas better! Please sign-up for a [developer account](https://nylas.com/register) for project updates and the latest news. Feel free to create issues or pull requests to start discussions.
-
-We require all authors sign our [Contributor License Agreement](https://www.nylas.com/cla.html) when submitting pull requests. (It's similar to other projects, like NodeJS or Meteor.)
-
-## Security
-
-For the sake of simplicity and setup speed, the development VM does not include any authentication or permission. For developing with sensitive data, we encourage developers to add their own protection, such as only running Nylas on a local machine or behind a controlled firewall.
-Note that passwords and OAuth tokens are stored unencrypted in the local MySQL data store on disk. This is intentional, for the same reason as above.
-
-## License
-
-This code is free software, licensed under the The GNU Affero General Public License (AGPL). See the `LICENSE` file for more details.
+Covers [Agent Accounts](https://developer.nylas.com/docs/v3/agent-accounts/), [Email](https://developer.nylas.com/docs/v3/email/), [Calendar](https://developer.nylas.com/docs/v3/calendar/), [Contacts](https://developer.nylas.com/docs/v3/email/contacts/), [Scheduler](https://developer.nylas.com/docs/v3/scheduler/), and [Notetaker](https://developer.nylas.com/docs/v3/notetaker/).

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ---
 
-# Nylas Sync Engine [![Build Status](https://travis-ci.org/nylas/sync-engine.svg?branch=master)](https://travis-ci.org/nylas/sync-engine)
+# Nylas Sync Engine
 
 The Nylas Sync Engine provides a RESTful API on top of a powerful email sync platform, making it easy to build apps on top of email. See the [full API documentation](https://www.nylas.com/docs/) for more details.
 
-Need help? [Join our Slack channel ![Slack Invite Button](http://slack-invite.nylas.com/badge.svg)](http://slack-invite.nylas.com)
+Need help? Join the [Nylas community forum](https://forums.nylas.com).
 
 
 ### Installation and Setup
@@ -70,7 +70,7 @@ We provide a fully managed and supported version of the Nylas sync engine for pr
 
 We'd love your help making Nylas better! Please sign-up for a [developer account](https://nylas.com/register) for project updates and the latest news. Feel free to create issues or pull requests to start discussions.
 
-We require all authors sign our [Contributor License Agreement](https://www.nylas.com/cla.html) when submitting pull requests. (It's similar to other projects, like NodeJS or Meteor.)
+We require all authors sign our Contributor License Agreement when submitting pull requests. (It's similar to other projects, like NodeJS or Meteor.)
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
+> [!CAUTION]
+> 🛑 **This repository is archived and no longer maintained.**
+>
+> The **Nylas Sync Engine** was an open-source email sync platform exposing a RESTful API on top of IMAP/SMTP; its capabilities now live on in the fully-hosted [Nylas API](https://developer.nylas.com/). Do not use it for new projects — see current Nylas resources below.
+
 <div align="center">
   <a href="https://www.nylas.com/">
     <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
   </a>
 
   <h1>Nylas Sync Engine</h1>
+
+  <p><img src="https://img.shields.io/badge/Status-Archived-critical?style=for-the-badge" alt="Status: Archived" /></p>
 </div>
 
 <br />
-
-> ## ⚠️ This repository is archived and no longer maintained
->
-> The **Nylas Sync Engine** was an open-source email sync platform that exposed a RESTful API on top of IMAP/SMTP. It is preserved here for historical reference and is no longer developed or supported. Its capabilities live on in the fully-hosted [Nylas API](https://developer.nylas.com/) — no self-hosting, no Vagrant, no infrastructure to run.
 
 ## Use the hosted Nylas API instead
 


### PR DESCRIPTION
Replaces the README with a concise **archived notice** that redirects visitors to the current hosted Nylas API.

The existing README documents the self-hosted v1 sync engine (Vagrant/VirtualBox setup, `docs.nylas.com`, Travis badge, `slack-invite.nylas.com`) — all long dead. Rather than leave link-rot on a 3.5k⭐ repo, this points people to the maintained platform.

**Intended as the "merge, then archive" step** — once merged, this repo can be archived (read-only). All links in the new README were verified to resolve (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)